### PR TITLE
TWP: Fix Various GCC Compiler Warnings

### DIFF
--- a/engines/twp/actorlib.cpp
+++ b/engines/twp/actorlib.cpp
@@ -333,7 +333,7 @@ static SQInteger actorInWalkbox(HSQUIRRELVM v) {
 	Common::String name;
 	if (SQ_FAILED(sqget(v, 3, name)))
 		return sq_throwerror(v, "failed to get name");
-	for (int i = 0; i < g_engine->_room->_walkboxes.size(); i++) {
+	for (int i = 0; i < (int)g_engine->_room->_walkboxes.size(); i++) {
 		const Walkbox &walkbox = g_engine->_room->_walkboxes[i];
 		if (walkbox._name == name) {
 			if (walkbox.contains(actor->_node->getAbsPos())) {
@@ -754,8 +754,8 @@ static SQInteger actorWalkTo(HSQUIRRELVM v) {
 		if (SQ_FAILED(sqget(v, 4, y)))
 			return sq_throwerror(v, "failed to get y");
 		Facing *facing = nullptr;
+		int dir;
 		if (nArgs == 5) {
-			int dir;
 			if (SQ_FAILED(sqget(v, 5, dir)))
 				return sq_throwerror(v, "failed to get dir");
 			facing = (Facing *)&dir;
@@ -933,7 +933,7 @@ static SQInteger is_actor(HSQUIRRELVM v) {
 // See also masterRoomArray.
 static SQInteger masterActorArray(HSQUIRRELVM v) {
 	sq_newarray(v, 0);
-	for (int i = 0; i < g_engine->_actors.size(); i++) {
+	for (int i = 0; i < (int)g_engine->_actors.size(); i++) {
 		Object *actor = g_engine->_actors[i];
 		sqpush(v, actor->_table);
 		sq_arrayappend(v, -2);

--- a/engines/twp/actorswitcher.cpp
+++ b/engines/twp/actorswitcher.cpp
@@ -32,12 +32,12 @@
 
 namespace Twp {
 
-ActorSwitcherSlot::ActorSwitcherSlot(const Common::String &icon, Color back, Color frame, SelectFunc *selectFunc, int id) {
-	this->icon = icon;
-	this->back = back;
-	this->frame = frame;
-	this->selectFunc = selectFunc;
-	this->id = id;
+ActorSwitcherSlot::ActorSwitcherSlot(const Common::String &icon_, Color back_, Color frame_, SelectFunc *selectFunc_, int id_) {
+	this->icon = icon_;
+	this->back = back_;
+	this->frame = frame_;
+	this->selectFunc = selectFunc_;
+	this->id = id_;
 }
 
 void ActorSwitcherSlot::select() {
@@ -60,7 +60,7 @@ Math::Matrix4 ActorSwitcher::transform(Math::Matrix4 trsf, int index) {
 }
 
 float ActorSwitcher::getAlpha(int index) const {
-	if (index == (_slots.size() - 1))
+	if (index == ((int)_slots.size() - 1))
 		return ENABLE_ALPHA;
 	if (_mode & asTemporaryUnselectable)
 		return INACTIVE_ALPHA;
@@ -85,7 +85,7 @@ void ActorSwitcher::drawIcon(const Common::String &icon, Color backColor, Color 
 
 void ActorSwitcher::drawCore(Math::Matrix4 trsf) {
 	if (_mouseOver) {
-		for (int i = 0; i < _slots.size(); i++) {
+		for (int i = 0; i < (int)_slots.size(); i++) {
 			ActorSwitcherSlot &slot = _slots[i];
 			drawIcon(slot.icon, slot.back, slot.frame, trsf, i);
 		}
@@ -153,7 +153,7 @@ void ActorSwitcher::update(const Common::Array<ActorSwitcherSlot> &slots, float 
 			_down = true;
 			// check if we allow to select an actor
 			int iconIdx = iconIndex(scrPos);
-			if ((_mode & asOn) || (iconIdx == (_slots.size() - 1))) {
+			if ((_mode & asOn) || (iconIdx == ((int)_slots.size() - 1))) {
 				if (_slots[iconIdx].selectFunc != nullptr)
 					_slots[iconIdx].select();
 			}

--- a/engines/twp/actorswitcher.h
+++ b/engines/twp/actorswitcher.h
@@ -35,7 +35,7 @@ typedef void SelectFunc(int id);
 
 // This is where all the information about the actor icon stands
 struct ActorSwitcherSlot {
-	ActorSwitcherSlot(const Common::String& icon, Color back, Color frame, SelectFunc* selectFunc, int id = 0);
+	ActorSwitcherSlot(const Common::String& icon_, Color back_, Color frame_, SelectFunc* selectFunc_, int id_ = 0);
 
 	void select();
 

--- a/engines/twp/clipper/clipper.cpp
+++ b/engines/twp/clipper/clipper.cpp
@@ -2998,7 +2998,7 @@ void Clipper::BuildResult(Paths &polys) {
     if (cnt < 2)
       continue;
     pg.reserve(cnt);
-    for (int i = 0; i < cnt; ++i) {
+    for (int j = 0; j < cnt; ++j) {
       pg.push_back(p->Pt);
       p = p->Prev;
     }

--- a/engines/twp/dialog.cpp
+++ b/engines/twp/dialog.cpp
@@ -197,7 +197,7 @@ void Dialog::choose(int choice) {
 void Dialog::choose(DialogSlot *slot) {
 	if (slot && slot->_isValid) {
 		sqcall("onChoiceClick");
-		for (int i = 0; i < slot->_stmt->_conds.size(); i++) {
+		for (int i = 0; i < (int)slot->_stmt->_conds.size(); i++) {
 			YCond *cond = slot->_stmt->_conds[i];
 			CondStateVisitor v(slot->_dlg, DialogSelMode::Choose);
 			cond->accept(v);
@@ -216,7 +216,10 @@ void Dialog::choose(DialogSlot *slot) {
 }
 
 void Dialog::start(const Common::String &actor, const Common::String &name, const Common::String &node) {
-	_context = DialogContext{.actor = actor, .dialogName = name, .parrot = true, .limit = MAXCHOICES};
+	_context.actor = actor;
+	_context.dialogName = name;
+	_context.parrot = true;
+	_context.limit = MAXCHOICES;
 	// keepIf(self.states, proc(x: DialogConditionState): bool = x.mode != TempOnce);
 	Common::String path = name + ".byack";
 	debug("start dialog %s", path.c_str());
@@ -349,7 +352,7 @@ void Dialog::selectLabel(int line, const Common::String &name) {
 void Dialog::gotoNextLabel() {
 	if (_lbl) {
 		int i = Twp::find(_cu->_labels, _lbl);
-		if ((i != -1) && (i != _cu->_labels.size() - 1)) {
+		if ((i != -1) && (i != (int)_cu->_labels.size() - 1)) {
 			YLabel *label = _cu->_labels[i + 1];
 			selectLabel(label->_line, label->_name);
 		} else {
@@ -400,11 +403,11 @@ void Dialog::running(float dt) {
 		_action->update(dt);
 	else if (!_lbl)
 		_state = None;
-	else if (_currentStatement == _lbl->_stmts.size())
+	else if (_currentStatement == (int)_lbl->_stmts.size())
 		gotoNextLabel();
 	else {
 		_state = Active;
-		while (_lbl && (_currentStatement < _lbl->_stmts.size()) && (_state == Active)) {
+		while (_lbl && (_currentStatement < (int)_lbl->_stmts.size()) && (_state == Active)) {
 			YStatement *statmt = _lbl->_stmts[_currentStatement];
 			IsChoice isChoice;
 			statmt->_exp->accept(isChoice);
@@ -420,7 +423,7 @@ void Dialog::running(float dt) {
 				return;
 			} else {
 				run(statmt);
-				if (_lbl && (_currentStatement == _lbl->_stmts.size()))
+				if (_lbl && (_currentStatement == (int)_lbl->_stmts.size()))
 					gotoNextLabel();
 			}
 		}

--- a/engines/twp/enginedialogtarget.cpp
+++ b/engines/twp/enginedialogtarget.cpp
@@ -54,7 +54,7 @@ private:
 
 static Object *actor(const Common::String &name) {
 	// for (actor in gEngine.actors) {
-	for (int i = 0; i < g_engine->_actors.size(); i++) {
+	for (int i = 0; i < (int)g_engine->_actors.size(); i++) {
 		Object *actor = g_engine->_actors[i];
 		if (actor->_key == name)
 			return actor;

--- a/engines/twp/font.cpp
+++ b/engines/twp/font.cpp
@@ -112,7 +112,7 @@ static int skipUntil(const Common::U32String& s, const char *until, int start = 
 static float width(Text &text, TokenReader &reader, Token tok) {
 	float result = 0;
 	Common::String s = reader.substr(tok);
-	for (int i = 0; i < s.size(); i++) {
+	for (int i = 0; i < (int)s.size(); i++) {
 		char c = s[i];
 		result += text.getFont()->getGlyph(c).advance;
 	}
@@ -135,7 +135,7 @@ CodePoint TokenReader::readChar() {
 TokenId TokenReader::readTokenId() {
 	const char Whitespace[] = {' ', '\t', '\v', '\r', '\f'};
 	const char Whitespace2[] = {' ', '\t', '\v', '\r', '\f', '#', '\n'};
-	if (_off < _text.size()) {
+	if (_off < (int)_text.size()) {
 		char c = readChar();
 		switch (c) {
 		case '\n':
@@ -301,11 +301,11 @@ void Text::update() {
 		float maxW;
 		float lineHeight = _font->getLineHeight();
 		float y = -lineHeight;
-		for (int i = 0; i < lines.size(); i++) {
+		for (int i = 0; i < (int)lines.size(); i++) {
 			Line &line = lines[i];
 			CodePoint prevChar;
 			x = 0;
-			for (int j = 0; j < line.tokens.size(); j++) {
+			for (int j = 0; j < (int)line.tokens.size(); j++) {
 				tok = line.tokens[j];
 				if (tok.id == tiColor) {
 					int iColor;
@@ -314,7 +314,7 @@ void Text::update() {
 					color = Color::withAlpha(Color::rgb(iColor & 0x00FFFFFF), color.rgba.a);
 				} else {
 					Common::U32String s = reader.substr(tok);
-					for (int k = 0; k < s.size(); k++) {
+					for (int k = 0; k < (int)s.size(); k++) {
 						CodePoint c = s[k];
 						Glyph glyph = _font->getGlyph(c);
 						float kern = _font->getKerning(prevChar, c);
@@ -332,17 +332,17 @@ void Text::update() {
 
 		// Align text
 		if (_hAlign == thRight) {
-			for (int i = 0; i < lines.size(); i++) {
+			for (int i = 0; i < (int)lines.size(); i++) {
 				float w = maxW - _quads[i].width();
-				for (int j = 0; j < lines[i].charInfos.size(); j++) {
+				for (int j = 0; j < (int)lines[i].charInfos.size(); j++) {
 					CharInfo &info = lines[i].charInfos[j];
 					info.pos.setX(info.pos.getX() + w);
 				}
 			}
 		} else if (_hAlign == thCenter) {
-			for (int i = 0; i < lines.size(); i++) {
+			for (int i = 0; i < (int)lines.size(); i++) {
 				float w = maxW - _quads[i].width();
-				for (int j = 0; j < lines[i].charInfos.size(); j++) {
+				for (int j = 0; j < (int)lines[i].charInfos.size(); j++) {
 					CharInfo &info = lines[i].charInfos[j];
 					info.pos.setX(info.pos.getX() + w / 2.f);
 				}
@@ -350,8 +350,8 @@ void Text::update() {
 		}
 
 		// Add the glyphs to the vertices
-		for (int i = 0; i < lines.size(); i++) {
-			for (int j = 0; j < lines[i].charInfos.size(); j++) {
+		for (int i = 0; i < (int)lines.size(); i++) {
+			for (int j = 0; j < (int)lines[i].charInfos.size(); j++) {
 				const CharInfo &info = lines[i].charInfos[j];
 				addGlyphQuad(_texture, _vertices, info);
 			}

--- a/engines/twp/genlib.cpp
+++ b/engines/twp/genlib.cpp
@@ -744,9 +744,9 @@ static SQInteger stopSentence(HSQUIRRELVM v) {
 	SQInteger nArgs = sq_gettop(v);
 	switch (nArgs) {
 	case 1: {
-		for (int i = 0; i < g_engine->_room->_layers.size(); i++) {
+		for (int i = 0; i < (int)g_engine->_room->_layers.size(); i++) {
 			Layer *layer = g_engine->_room->_layers[i];
-			for (int j = 0; j < layer->_objects.size(); j++) {
+			for (int j = 0; j < (int)layer->_objects.size(); j++) {
 				Object *obj = layer->_objects[j];
 				obj->_exec.enabled = false;
 			}

--- a/engines/twp/gfx.cpp
+++ b/engines/twp/gfx.cpp
@@ -343,12 +343,16 @@ void Gfx::drawPrimitives(uint32 primitivesType, Vertex *vertices, int v_size, ui
 
 		GL_CALL(glBindBuffer(GL_ARRAY_BUFFER, _vbo));
 
-		GL_CALL(glEnableVertexAttribArray(0));
-		GL_CALL(glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void *)0));
-		GL_CALL(glEnableVertexAttribArray(2));
-		GL_CALL(glVertexAttribPointer(2, 4, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void *)(2 * sizeof(float))));
-		GL_CALL(glEnableVertexAttribArray(1));
-		GL_CALL(glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void *)(6 * sizeof(float))));
+		int posLoc = glGetAttribLocation(_defaultShader.program, "a_position");
+		int colLoc = glGetAttribLocation(_defaultShader.program, "a_color");
+		int texCoordsLoc = glGetAttribLocation(_defaultShader.program, "a_texCoords");
+		GL_CALL(glBindBuffer(GL_ARRAY_BUFFER, _vbo));
+		GL_CALL(glEnableVertexAttribArray(posLoc));
+		GL_CALL(glVertexAttribPointer(posLoc, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void *)0));
+		GL_CALL(glEnableVertexAttribArray(colLoc));
+		GL_CALL(glVertexAttribPointer(colLoc, 4, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void *)(2 * sizeof(float))));
+		GL_CALL(glEnableVertexAttribArray(texCoordsLoc));
+		GL_CALL(glVertexAttribPointer(texCoordsLoc, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void *)(6 * sizeof(float))));
 
 		GL_CALL(glBindBuffer(GL_ARRAY_BUFFER, _vbo));
 		GL_CALL(glBufferData(GL_ARRAY_BUFFER, sizeof(Vertex) * v_size, vertices, GL_STREAM_DRAW));

--- a/engines/twp/gfx.cpp
+++ b/engines/twp/gfx.cpp
@@ -88,11 +88,11 @@ void Texture::capture(Graphics::Surface &surface) {
 	GLint boundFrameBuffer;
 
 	glGetIntegerv(GL_FRAMEBUFFER_BINDING, &boundFrameBuffer);
-	if (boundFrameBuffer != fbo) {
+	if (boundFrameBuffer != (GLint)fbo) {
 		glBindFramebuffer(GL_FRAMEBUFFER, fbo);
 	}
 	glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, &pixels[0]);
-	if (boundFrameBuffer != fbo) {
+	if (boundFrameBuffer !=(GLint)fbo) {
 		glBindFramebuffer(GL_FRAMEBUFFER, boundFrameBuffer);
 	}
 	Graphics::PixelFormat fmt(4, 8, 8, 8, 8, 0, 8, 16, 24);

--- a/engines/twp/gfx.cpp
+++ b/engines/twp/gfx.cpp
@@ -305,7 +305,6 @@ void Gfx::drawPrimitives(uint32 primitivesType, Vertex *vertices, int v_size, Ma
 
 		GL_CALL(glActiveTexture(GL_TEXTURE0));
 		GL_CALL(glBindTexture(GL_TEXTURE_2D, _texture->id));
-		GL_CALL(glUniform1i(0, 0));
 
 		Math::Matrix4 m = getFinalTransform(trsf);
 		_shader->setUniform("u_transform", m);

--- a/engines/twp/ggpack.cpp
+++ b/engines/twp/ggpack.cpp
@@ -418,7 +418,7 @@ Common::JSONValue *GGHashMapDecoder::readArray() {
 		error("trying to parse a non-array");
 	Common::JSONArray arr;
 	uint32 length = _stream->readUint32LE();
-	for (int i = 0; i < length; i++) {
+	for (uint32 i = 0; i < length; i++) {
 		Common::JSONValue *item = readValue();
 		arr.push_back(item);
 	}
@@ -435,7 +435,7 @@ Common::JSONValue *GGHashMapDecoder::readHash() {
 		error("trying to parse a non-hash: %d", c);
 	}
 	uint32 nPairs = _stream->readUint32LE();
-	for (int i = 0; i < nPairs; i++) {
+	for (uint32 i = 0; i < nPairs; i++) {
 		Common::String key = readString(_stream->readUint32LE());
 		obj[key] = readValue();
 	}
@@ -456,7 +456,8 @@ Common::JSONValue *GGHashMapDecoder::open(Common::SeekableReadStream *s) {
 		return nullptr;
 	}
 	_stream = s;
-	(void)s->readUint32LE();
+	/*uint32 numEntries =*/ (void)s->readUint32LE();
+
 	if (!_readPlo(s, _offsets))
 		return nullptr;
 	return readHash();
@@ -553,7 +554,7 @@ uint32 XorStream::read(void *dataPtr, uint32 dataSize) {
 	int p = (int)pos();
 	uint32 result = _s->read(dataPtr, dataSize);
 	char *buf = (char *)dataPtr;
-	for (int i = 0; i < dataSize; i++) {
+	for (uint32 i = 0; i < dataSize; i++) {
 		int x = buf[i] ^ _key.magicBytes[p & 0x0F] ^ (i * _key.multiplier);
 		buf[i] = (char)(x ^ _previous);
 		_previous = x;
@@ -642,7 +643,7 @@ bool GGPackEntryReader::open(GGPackDecoder &pack, const Common::String &entry) {
 }
 
 bool GGPackEntryReader::open(GGPackSet &packs, const Common::String &entry) {
-	for (int i = 0; i < packs._packs.size(); i++) {
+	for (int i = 0; i < (int)packs._packs.size(); i++) {
 		GGPackDecoder *pack = &packs._packs[i];
 		if (open(*pack, entry))
 			return true;
@@ -725,7 +726,7 @@ void GGPackSet::init() {
 }
 
 bool GGPackSet::assetExists(const char *asset) {
-	for (int i = 0; i < _packs.size(); i++) {
+	for (int i = 0; i < (int)_packs.size(); i++) {
 		GGPackDecoder *pack = &_packs[i];
 		if (pack->assetExists(asset))
 			return true;

--- a/engines/twp/graph.cpp
+++ b/engines/twp/graph.cpp
@@ -114,10 +114,10 @@ Graph::Graph() {}
 Graph::Graph(const Graph &graph) {
 	_nodes = graph._nodes;
 	_concaveVertices = graph._concaveVertices;
-	for (int i = 0; i < graph._edges.size(); i++) {
+	for (int i = 0; i < (int)graph._edges.size(); i++) {
 		const Common::Array<GraphEdge> &e = graph._edges[i];
 		Common::Array<GraphEdge> sEdges;
-		for (int j = 0; j < e.size(); j++) {
+		for (int j = 0; j < (int)e.size(); j++) {
 			const GraphEdge &se = e[j];
 			sEdges.push_back(GraphEdge(se.start, se.to, se.cost));
 		}
@@ -158,7 +158,7 @@ void AStar::search(int source, int target) {
 		_spt[NCN] = _sf[NCN];
 		if (NCN != target) {
 			// for (edge in _graph->edges[NCN]) {
-			for (int i = 0; i < _graph->_edges[NCN].size(); i++) {
+			for (int i = 0; i < (int)_graph->_edges[NCN].size(); i++) {
 				GraphEdge &edge = _graph->_edges[NCN][i];
 				float Hcost = length(_graph->_nodes[edge.to] - _graph->_nodes[target]);
 				float Gcost = _gCost[NCN] + edge.cost;
@@ -190,7 +190,7 @@ void Graph::addEdge(GraphEdge e) {
 
 GraphEdge *Graph::edge(int start, int to) {
 	Common::Array<GraphEdge> &edges = _edges[start];
-	for (int i = 0; i < edges.size(); i++) {
+	for (int i = 0; i < (int)edges.size(); i++) {
 		GraphEdge *e = &edges[i];
 		if (e->to == to)
 			return e;
@@ -200,7 +200,7 @@ GraphEdge *Graph::edge(int start, int to) {
 
 Common::Array<int> reverse(const Common::Array<int> &arr) {
 	Common::Array<int> result(arr.size());
-	for (int i = 0; i < arr.size(); i++) {
+	for (int i = 0; i < (int)arr.size(); i++) {
 		result[arr.size() - 1 - i] = arr[i];
 	}
 	return result;
@@ -241,7 +241,7 @@ static bool inside(const Walkbox &self, Math::Vector2d position, bool toleranceO
 	Math::Vector2d oldPoint(polygon[polygon.size() - 1]);
 	float oldSqDist = distanceSquared(oldPoint, point);
 
-	for (int i = 0; i < polygon.size(); i++) {
+	for (int i = 0; i < (int)polygon.size(); i++) {
 		Math::Vector2d newPoint = polygon[i];
 		float newSqDist = distanceSquared(newPoint, point);
 
@@ -273,7 +273,7 @@ Math::Vector2d Walkbox::getClosestPointOnEdge(Math::Vector2d p3) const {
 	float minDist = 100000.0f;
 
 	const Common::Array<Math::Vector2d> &polygon = getPoints();
-	for (int i = 0; i < polygon.size(); i++) {
+	for (int i = 0; i < (int)polygon.size(); i++) {
 		float dist = distanceToSegment(p3, polygon[i], polygon[(i + 1) % polygon.size()]);
 		if (dist < minDist) {
 			minDist = dist;
@@ -305,7 +305,7 @@ Math::Vector2d Walkbox::getClosestPointOnEdge(Math::Vector2d p3) const {
 }
 
 static bool less(Math::Vector2d p1, Math::Vector2d p2) {
-	return ((p1.getX() < p2.getX() - EPSILON) || (abs(p1.getX() - p2.getX()) < EPSILON) && (p1.getY() < p2.getY() - EPSILON));
+	return ((p1.getX() < p2.getX() - EPSILON) || ((abs(p1.getX() - p2.getX()) < EPSILON) && (p1.getY() < p2.getY() - EPSILON)));
 }
 
 static float det(float a, float b, float c, float d) {
@@ -368,7 +368,7 @@ bool PathFinder::inLineOfSight(Math::Vector2d start, Math::Vector2d to) {
 		return true;
 
 	// Not in LOS if any edge is intersected by the start-end line segment
-	for (int i = 0; i < _walkboxes.size(); i++) {
+	for (int i = 0; i < (int)_walkboxes.size(); i++) {
 		Walkbox &walkbox = _walkboxes[i];
 		const Common::Array<Math::Vector2d> &polygon = walkbox.getPoints();
 		int size = polygon.size();
@@ -387,7 +387,7 @@ bool PathFinder::inLineOfSight(Math::Vector2d start, Math::Vector2d to) {
 	// Finally the middle point in the segment determines if in LOS or not
 	Math::Vector2d v2 = (start + to) / 2.0f;
 	bool result = _walkboxes[0].contains(v2);
-	for (int i = 1; i < _walkboxes.size(); i++) {
+	for (int i = 1; i < (int)_walkboxes.size(); i++) {
 		if (_walkboxes[i].contains(v2, false))
 			result = false;
 	}
@@ -397,7 +397,7 @@ bool PathFinder::inLineOfSight(Math::Vector2d start, Math::Vector2d to) {
 static int minIndex(const Common::Array<float> values) {
 	float min = values[0];
 	int index = 0;
-	for (int i = 1; i < values.size(); i++) {
+	for (int i = 1; i < (int)values.size(); i++) {
 		if (values[i] < min) {
 			index = i;
 			min = values[i];
@@ -408,11 +408,11 @@ static int minIndex(const Common::Array<float> values) {
 
 Graph *PathFinder::createGraph() {
 	Graph *result = new Graph();
-	for (int i = 0; i < _walkboxes.size(); i++) {
+	for (int i = 0; i < (int)_walkboxes.size(); i++) {
 		Walkbox &walkbox = _walkboxes[i];
 		if (walkbox.getPoints().size() > 2) {
 			bool visible = walkbox.isVisible();
-			for (int j = 0; j < walkbox.getPoints().size(); j++) {
+			for (int j = 0; j < (int)walkbox.getPoints().size(); j++) {
 				if (walkbox.concave(j) == visible) {
 					Math::Vector2d vertex = walkbox.getPoints()[j];
 					result->_concaveVertices.push_back(vertex);
@@ -422,8 +422,8 @@ Graph *PathFinder::createGraph() {
 		}
 	}
 
-	for (int i = 0; i < result->_concaveVertices.size(); i++) {
-		for (int j = 0; j < result->_concaveVertices.size(); j++) {
+	for (int i = 0; i < (int)result->_concaveVertices.size(); i++) {
+		for (int j = 0; j < (int)result->_concaveVertices.size(); j++) {
 			Math::Vector2d c1(result->_concaveVertices[i]);
 			Math::Vector2d c2(result->_concaveVertices[j]);
 			if (inLineOfSight(c1, c2)) {
@@ -439,7 +439,7 @@ Common::Array<Math::Vector2d> PathFinder::calculatePath(Math::Vector2d start, Ma
 	Common::Array<Math::Vector2d> result;
 	if (_walkboxes.size() > 0) {
 		// find the walkbox where the actor is and put it first
-		for (int i = 0; i < _walkboxes.size(); i++) {
+		for (int i = 0; i < (int)_walkboxes.size(); i++) {
 			const Walkbox &wb = _walkboxes[i];
 			if (inside(wb, start) && (i != 0)) {
 				SWAP(_walkboxes[0], _walkboxes[i]);
@@ -450,7 +450,7 @@ Common::Array<Math::Vector2d> PathFinder::calculatePath(Math::Vector2d start, Ma
 		// if no walkbox has been found => find the nearest walkbox
 		if (!inside(_walkboxes[0], start)) {
 			Common::Array<float> dists(_walkboxes.size());
-			for (int i = 0; i < _walkboxes.size(); i++) {
+			for (int i = 0; i < (int)_walkboxes.size(); i++) {
 				Walkbox wb = _walkboxes[i];
 				dists[i] = distance(wb.getClosestPointOnEdge(start), start);
 			}
@@ -474,7 +474,7 @@ Common::Array<Math::Vector2d> PathFinder::calculatePath(Math::Vector2d start, Ma
 
 		walkgraph->addNode(start);
 
-		for (int i = 0; i < walkgraph->_concaveVertices.size(); i++) {
+		for (int i = 0; i < (int)walkgraph->_concaveVertices.size(); i++) {
 			Math::Vector2d c = walkgraph->_concaveVertices[i];
 			if (inLineOfSight(start, c))
 				walkgraph->addEdge(GraphEdge(startNodeIndex, i, distance(start, c)));
@@ -484,7 +484,7 @@ Common::Array<Math::Vector2d> PathFinder::calculatePath(Math::Vector2d start, Ma
 		int endNodeIndex = walkgraph->_nodes.size();
 		walkgraph->addNode(to);
 
-		for (int i = 0; i < walkgraph->_concaveVertices.size(); i++) {
+		for (int i = 0; i < (int)walkgraph->_concaveVertices.size(); i++) {
 			Math::Vector2d c = walkgraph->_concaveVertices[i];
 			if (inLineOfSight(to, c))
 				walkgraph->addEdge(GraphEdge(i, endNodeIndex, distance(to, c)));
@@ -494,7 +494,7 @@ Common::Array<Math::Vector2d> PathFinder::calculatePath(Math::Vector2d start, Ma
 			walkgraph->addEdge(GraphEdge(startNodeIndex, endNodeIndex, distance(start, to)));
 
 		Common::Array<int> indices = walkgraph->getPath(startNodeIndex, endNodeIndex);
-		for (int i = 0; i < indices.size(); i++) {
+		for (int i = 0; i < (int)indices.size(); i++) {
 			int index = indices[i];
 			result.push_back(walkgraph->_nodes[index]);
 		}

--- a/engines/twp/hud.cpp
+++ b/engines/twp/hud.cpp
@@ -46,7 +46,7 @@ HudShader::HudShader() {
 }
 
 void HudShader::init() {
-	const char *vsrc = R"(#version 110
+	const char *v_source = R"(#version 110
 	attribute vec2 a_position;
 	attribute vec4 a_color;
 	attribute vec2 a_texCoords;
@@ -75,7 +75,7 @@ void HudShader::init() {
 		v_ranges = u_ranges;
 	})";
 
-	const char* fsrc = R"(#version 110
+	const char* f_source = R"(#version 110
 	varying vec4 v_color;
 	varying vec2 v_texCoords;
 	varying vec4 v_shadowColor;
@@ -98,7 +98,7 @@ void HudShader::init() {
 		texColor *= v_color;
 		gl_FragColor = texColor;
 	})";
-	Shader::init(vsrc, fsrc);
+	Shader::init(v_source, f_source);
 
 	GL_CALL(_rangesLoc = glGetUniformLocation(program, "u_ranges"));
 	GL_CALL(_shadowColorLoc = glGetUniformLocation(program, "u_shadowColor"));

--- a/engines/twp/ids.cpp
+++ b/engines/twp/ids.cpp
@@ -106,6 +106,7 @@ int newLightId() {
 
 Facing getOppositeFacing(Facing facing) {
 	switch (facing) {
+	default:
 	case FACE_FRONT:
 		return FACE_BACK;
 	case FACE_BACK:

--- a/engines/twp/lip.cpp
+++ b/engines/twp/lip.cpp
@@ -37,7 +37,7 @@ void Lip::load(Common::SeekableReadStream *stream) {
 char Lip::letter(float time) {
 	if (_items.size() == 0)
 		return 'A';
-	for (int i = 0; i < _items.size() - 1; i++) {
+	for (int i = 0; i < (int)_items.size() - 1; i++) {
 		if (time < _items[i + 1].time) {
 			return _items[i].letter;
 		}

--- a/engines/twp/object.cpp
+++ b/engines/twp/object.cpp
@@ -153,7 +153,7 @@ void Object::play(const Common::String &state, bool loop, bool instant) {
 }
 
 bool Object::playCore(const Common::String &state, bool loop, bool instant) {
-	for (int i = 0; i < _anims.size(); i++) {
+	for (int i = 0; i < (int)_anims.size(); i++) {
 		ObjectAnimation &anim = _anims[i];
 		if (anim.name == state) {
 			_animFlags = anim.flags;
@@ -172,7 +172,7 @@ bool Object::playCore(const Common::String &state, bool loop, bool instant) {
 
 void Object::showLayer(const Common::String &layer, bool visible) {
 	int index = -1;
-	for (int i = 0; i < _hiddenLayers.size(); i++) {
+	for (int i = 0; i < (int)_hiddenLayers.size(); i++) {
 		if (_hiddenLayers[i] == layer) {
 			index = i;
 			break;
@@ -187,7 +187,7 @@ void Object::showLayer(const Common::String &layer, bool visible) {
 			_hiddenLayers.push_back(layer);
 	}
 	if (_node != NULL) {
-		for (int i = 0; i < _node->getChildren().size(); i++) {
+		for (int i = 0; i < (int)_node->getChildren().size(); i++) {
 			Node *node = _node->getChildren()[i];
 			if (node->getName() == layer) {
 				node->setVisible(visible);
@@ -199,7 +199,7 @@ void Object::showLayer(const Common::String &layer, bool visible) {
 Facing Object::getFacing() const {
 	if (_facingLockValue != 0)
 		return (Facing)_facingLockValue;
-	for (int i = 0; i < _facingMap.size(); i++) {
+	for (int i = 0; i < (int)_facingMap.size(); i++) {
 		if (_facingMap[i].key == _facing)
 			return _facingMap[i].value;
 	}
@@ -231,6 +231,7 @@ Common::String Object::suffix() const {
 	switch (getFacing()) {
 	case FACE_BACK:
 		return "_back";
+	default:
 	case FACE_FRONT:
 		return "_front";
 	case FACE_LEFT:

--- a/engines/twp/rectf.cpp
+++ b/engines/twp/rectf.cpp
@@ -40,8 +40,8 @@ Rectf Rectf::fromMinMax(Math::Vector2d min, Math::Vector2d max) {
 	return {min.getX(), min.getY(), max.getX() - min.getX() + 1, max.getY() - min.getY() + 1};
 }
 
-Rectf Rectf::operator/(Math::Vector2d v) {
-	return Rectf(r.x / v.getX(), r.y / v.getY(), r.w / v.getX(), r.h / v.getY());
+Rectf Rectf::operator/(Math::Vector2d nv) {
+	return Rectf(r.x / nv.getX(), r.y / nv.getY(), r.w / nv.getX(), r.h / nv.getY());
 }
 
 } // namespace Twp

--- a/engines/twp/room.cpp
+++ b/engines/twp/room.cpp
@@ -81,7 +81,7 @@ static Walkbox parseWalkbox(const Common::String &text) {
 		long y = std::strtol(text.substr(commaPos + 1, endPos - commaPos - 1).c_str(), nullptr, 10);
 		i = endPos + 3;
 		points.push_back({(float)x, (float)y});
-	} while ((text.size() - 1) != endPos);
+	} while (((int)text.size() - 1) != endPos);
 	return Walkbox(points);
 }
 
@@ -100,7 +100,7 @@ static Scaling parseScaling(const Common::JSONArray &jScalings) {
 static ClipperLib::Path toPolygon(const Walkbox &walkbox) {
 	ClipperLib::Path path;
 	const Common::Array<Math::Vector2d> &points = walkbox.getPoints();
-	for (int i = 0; i < points.size(); i++) {
+	for (int i = 0; i < (int)points.size(); i++) {
 		path.push_back(ClipperLib::IntPoint(points[i].getX(), points[i].getY()));
 	}
 	return path;
@@ -108,7 +108,7 @@ static ClipperLib::Path toPolygon(const Walkbox &walkbox) {
 
 static Walkbox toWalkbox(const ClipperLib::Path &path) {
 	Common::Array<Math::Vector2d> pts;
-	for (int i = 0; i < path.size(); i++) {
+	for (int i = 0; i < (int)path.size(); i++) {
 		const ClipperLib::IntPoint &pt = path[i];
 		pts.push_back(Math::Vector2d(pt.X, pt.Y));
 	}
@@ -119,7 +119,7 @@ static Common::Array<Walkbox> merge(const Common::Array<Walkbox> &walkboxes) {
 	Common::Array<Walkbox> result;
 	if (walkboxes.size() > 0) {
 		ClipperLib::Paths subjects, clips;
-		for (int i = 0; i < walkboxes.size(); i++) {
+		for (int i = 0; i < (int)walkboxes.size(); i++) {
 			const Walkbox &wb = walkboxes[i];
 			if (wb.isVisible()) {
 				subjects.push_back(toPolygon(wb));
@@ -134,7 +134,7 @@ static Common::Array<Walkbox> merge(const Common::Array<Walkbox> &walkboxes) {
 		c.AddPaths(clips, ClipperLib::ptClip, true);
 		c.Execute(ClipperLib::ClipType::ctDifference, solutions, ClipperLib::pftEvenOdd);
 
-		for (int i = 0; i < solutions.size(); i++) {
+		for (int i = 0; i < (int)solutions.size(); i++) {
 			result.push_back(toWalkbox(solutions[i]));
 		}
 	}
@@ -149,7 +149,7 @@ Room::Room(const Common::String &name, HSQOBJECT &table) : _table(table) {
 }
 
 Room::~Room() {
-	for (int i = 0; i < _layers.size(); i++) {
+	for (int i = 0; i < (int)_layers.size(); i++) {
 		delete _layers[i];
 	}
 	delete _scene;
@@ -271,7 +271,7 @@ void Room::load(Common::SeekableReadStream &s) {
 		backNames.push_back(jRoom["background"]->asString());
 	} else {
 		const Common::JSONArray &jBacks = jRoom["background"]->asArray();
-		for (int i = 0; i < jBacks.size(); i++) {
+		for (int i = 0; i < (int)jBacks.size(); i++) {
 			backNames.push_back(jBacks[i]->asString());
 		}
 	}
@@ -284,12 +284,12 @@ void Room::load(Common::SeekableReadStream &s) {
 	// layers
 	if (jRoom.contains("layers")) {
 		const Common::JSONArray &jLayers = jRoom["layers"]->asArray();
-		for (int i = 0; i < jLayers.size(); i++) {
+		for (int i = 0; i < (int)jLayers.size(); i++) {
 			Common::StringArray names;
 			const Common::JSONObject &jLayer = jLayers[i]->asObject();
 			if (jLayer["name"]->isArray()) {
 				const Common::JSONArray &jNames = jLayer["name"]->asArray();
-				for (int j = 0; j < jNames.size(); j++) {
+				for (int j = 0; j < (int)jNames.size(); j++) {
 					names.push_back(jNames[j]->asString());
 				}
 			} else if (jLayer["name"]->isString()) {
@@ -370,7 +370,7 @@ void Room::load(Common::SeekableReadStream &s) {
 
 	// Fix room size (why ?)
 	int width = 0;
-	for (int i = 0; i < backNames.size(); i++) {
+	for (int i = 0; i < (int)backNames.size(); i++) {
 		Common::String name = backNames[i];
 		width += g_engine->_resManager.spriteSheet(_sheet)->frameTable[name].sourceSize.getX();
 	}
@@ -380,7 +380,7 @@ void Room::load(Common::SeekableReadStream &s) {
 }
 
 Layer *Room::layer(int zsort) {
-	for (int i = 0; i < _layers.size(); i++) {
+	for (int i = 0; i < (int)_layers.size(); i++) {
 		Layer *l = _layers[i];
 		if (l->_zsort == zsort)
 			return l;
@@ -402,9 +402,9 @@ Math::Vector2d Room::getScreenSize() {
 }
 
 Object *Room::getObj(const Common::String &key) {
-	for (int i = 0; i < _layers.size(); i++) {
+	for (int i = 0; i < (int)_layers.size(); i++) {
 		Layer *layer = _layers[i];
-		for (int j = 0; j < layer->_objects.size(); j++) {
+		for (int j = 0; j < (int)layer->_objects.size(); j++) {
 			Object *obj = layer->_objects[j];
 			if (obj->_key == key)
 				return obj;
@@ -455,9 +455,9 @@ void Room::update(float elapsed) {
 		_overlayTo->update(elapsed);
 	// if (_rotateTo)
 	// 	_rotateTo->update(elapsedSec);
-	for (int j = 0; j < _layers.size(); j++) {
+	for (int j = 0; j < (int)_layers.size(); j++) {
 		Layer *layer = _layers[j];
-		for (int k = 0; k < layer->_objects.size(); k++) {
+		for (int k = 0; k < (int)layer->_objects.size(); k++) {
 			Object *obj = layer->_objects[k];
 			obj->update(elapsed);
 		}
@@ -465,7 +465,7 @@ void Room::update(float elapsed) {
 }
 
 void Room::walkboxHidden(const Common::String &name, bool hidden) {
-	for (int i = 0; i < _walkboxes.size(); i++) {
+	for (int i = 0; i < (int)_walkboxes.size(); i++) {
 		Walkbox &wb = _walkboxes[i];
 		if (wb._name == name) {
 			wb.setVisible(!hidden);
@@ -528,7 +528,7 @@ bool Walkbox::contains(Math::Vector2d position, bool toleranceOnOutside) const {
 	Math::Vector2d oldPoint(_polygon[_polygon.size() - 1]);
 	float oldSqDist = distanceSquared(oldPoint, point);
 
-	for (int i = 0; i < _polygon.size(); i++) {
+	for (int i = 0; i < (int)_polygon.size(); i++) {
 		Math::Vector2d newPoint = _polygon[i];
 		float newSqDist = distanceSquared(newPoint, point);
 
@@ -557,7 +557,7 @@ bool Walkbox::contains(Math::Vector2d position, bool toleranceOnOutside) const {
 float Scaling::getScaling(float yPos) {
 	if (values.size() == 0)
 		return 1.0f;
-	for (int i = 0; i < values.size(); i++) {
+	for (int i = 0; i < (int)values.size(); i++) {
 		ScalingValue scaling = values[i];
 		if (yPos < scaling.y) {
 			if (i == 0)

--- a/engines/twp/roomlib.cpp
+++ b/engines/twp/roomlib.cpp
@@ -78,7 +78,7 @@ static SQInteger clampInWalkbox(HSQUIRRELVM v) {
 		return sq_throwerror(v, "Invalid argument number in clampInWalkbox");
 	}
 	const Common::Array<Walkbox> &walkboxes = g_engine->_room->_walkboxes;
-	for (int i = 0; i < walkboxes.size(); i++) {
+	for (int i = 0; i < (int)walkboxes.size(); i++) {
 		const Walkbox &walkbox = walkboxes[i];
 		if (walkbox.contains(pos1)) {
 			sqpush(v, pos1);
@@ -228,7 +228,7 @@ static SQInteger findRoom(HSQUIRRELVM v) {
 	Common::String name;
 	if (SQ_FAILED(sqget(v, 2, name)))
 		return sq_throwerror(v, "failed to get name");
-	for (int i = 0; i < g_engine->_rooms.size(); i++) {
+	for (int i = 0; i < (int)g_engine->_rooms.size(); i++) {
 		Room *room = g_engine->_rooms[i];
 		if (room->_name == name) {
 			sqpush(v, room->_table);
@@ -252,7 +252,7 @@ static SQInteger findRoom(HSQUIRRELVM v) {
 // }
 static SQInteger masterRoomArray(HSQUIRRELVM v) {
 	sq_newarray(v, 0);
-	for (int i = 0; i < g_engine->_rooms.size(); i++) {
+	for (int i = 0; i < (int)g_engine->_rooms.size(); i++) {
 		Room *room = g_engine->_rooms[i];
 		sq_pushobject(v, room->_table);
 		sq_arrayappend(v, -2);
@@ -268,7 +268,7 @@ static SQInteger removeTrigger(HSQUIRRELVM v) {
 		sq_resetobject(&closure);
 		if (SQ_FAILED(sqget(v, 3, closure)))
 			return sq_throwerror(v, "failed to get closure");
-		for (int i = 0; i < g_engine->_room->_triggers.size(); i++) {
+		for (int i = 0; i < (int)g_engine->_room->_triggers.size(); i++) {
 			Object *trigger = g_engine->_room->_triggers[i];
 			if ((trigger->_enter._unVal.pClosure == closure._unVal.pClosure) || (trigger->_leave._unVal.pClosure == closure._unVal.pClosure)) {
 				g_engine->_room->_triggers.remove_at(i);
@@ -303,7 +303,7 @@ static SQInteger roomActors(HSQUIRRELVM v) {
 		return sq_throwerror(v, "failed to get room");
 
 	sq_newarray(v, 0);
-	for (int i = 0; i < g_engine->_actors.size(); i++) {
+	for (int i = 0; i < (int)g_engine->_actors.size(); i++) {
 		Object *actor = g_engine->_actors[i];
 		if (actor->_room == room) {
 			sqpush(v, actor->_table);

--- a/engines/twp/savegame.cpp
+++ b/engines/twp/savegame.cpp
@@ -27,7 +27,7 @@
 namespace Twp {
 
 static Object *actor(const Common::String &key) {
-	for (int i = 0; i < g_engine->_actors.size(); i++) {
+	for (int i = 0; i < (int)g_engine->_actors.size(); i++) {
 		Object *a = g_engine->_actors[i];
 		if (a->_key == key)
 			return a;
@@ -56,18 +56,18 @@ static DialogConditionMode parseMode(char mode) {
 static DialogConditionState parseState(Common::String &dialog) {
 	Common::String dialogName;
 	int i = 1;
-	while (i < dialog.size() && !Common::isDigit(dialog[i])) {
+	while (i < (int)dialog.size() && !Common::isDigit(dialog[i])) {
 		dialogName += dialog[i];
 		i++;
 	}
 
-	while (!g_engine->_pack.assetExists((dialogName + ".byack").c_str()) && (i < dialog.size())) {
+	while (!g_engine->_pack.assetExists((dialogName + ".byack").c_str()) && (i < (int)dialog.size())) {
 		dialogName += dialog[i];
 		i++;
 	}
 
 	Common::String num;
-	while ((i < dialog.size()) && Common::isDigit(dialog[i])) {
+	while ((i < (int)dialog.size()) && Common::isDigit(dialog[i])) {
 		num += dialog[i];
 		i++;
 	}
@@ -81,7 +81,7 @@ static DialogConditionState parseState(Common::String &dialog) {
 }
 
 static Room *room(const Common::String &name) {
-	for (int i = 0; i < g_engine->_rooms.size(); i++) {
+	for (int i = 0; i < (int)g_engine->_rooms.size(); i++) {
 		Room *room = g_engine->_rooms[i];
 		if (room->_name == name) {
 			return room;
@@ -91,9 +91,9 @@ static Room *room(const Common::String &name) {
 }
 
 static Object *object(Room *room, const Common::String &key) {
-	for (int i = 0; i < room->_layers.size(); i++) {
+	for (int i = 0; i < (int)room->_layers.size(); i++) {
 		Layer *layer = room->_layers[i];
-		for (int j = 0; j < layer->_objects.size(); j++) {
+		for (int j = 0; j < (int)layer->_objects.size(); j++) {
 			Object *o = layer->_objects[j];
 			if (o->_key == key)
 				return o;
@@ -103,11 +103,11 @@ static Object *object(Room *room, const Common::String &key) {
 }
 
 static Object *object(const Common::String &key) {
-	for (int i = 0; i < g_engine->_rooms.size(); i++) {
+	for (int i = 0; i < (int)g_engine->_rooms.size(); i++) {
 		Room *room = g_engine->_rooms[i];
-		for (int j = 0; j < room->_layers.size(); j++) {
+		for (int j = 0; j < (int)room->_layers.size(); j++) {
 			Layer *layer = room->_layers[j];
-			for (int k = 0; k < layer->_objects.size(); k++) {
+			for (int k = 0; k < (int)layer->_objects.size(); k++) {
 				Object *o = layer->_objects[k];
 				if (o->_key == key)
 					return o;
@@ -137,7 +137,7 @@ static void toSquirrel(const Common::JSONValue *json, HSQOBJECT &obj) {
 	} else if (json->isArray()) {
 		sq_newarray(v, 0);
 		const Common::JSONArray &jArr = json->asArray();
-		for (int i = 0; i < jArr.size(); i++) {
+		for (int i = 0; i < (int)jArr.size(); i++) {
 			HSQOBJECT tmp;
 			toSquirrel(jArr[i], tmp);
 			sqpush(v, tmp);
@@ -356,7 +356,7 @@ static void loadRoom(Room *room, const Common::JSONObject &json) {
 }
 
 static void setActor(const Common::String &key) {
-	for (int i = 0; i < g_engine->_actors.size(); i++) {
+	for (int i = 0; i < (int)g_engine->_actors.size(); i++) {
 		Object *a = g_engine->_actors[i];
 		if (a->_key == key) {
 			g_engine->setActor(a, false);
@@ -438,7 +438,7 @@ void SaveGameManager::loadGameScene(const Common::JSONObject &json) {
 	g_engine->_actorSwitcher._mode = mode;
 	// TODO: tmpPrefs().forceTalkieText = json["forceTalkieText"].getInt() != 0;
 	const Common::JSONArray &jSelectableActors = json["selectableActors"]->asArray();
-	for (int i = 0; i < jSelectableActors.size(); i++) {
+	for (int i = 0; i < (int)jSelectableActors.size(); i++) {
 		const Common::JSONObject &jSelectableActor = jSelectableActors[i]->asObject();
 		Object *act = jSelectableActor.contains("_actorKey") ? actor(jSelectableActor["_actorKey"]->asString()) : nullptr;
 		g_engine->_hud._actorSlots[i].actor = act;
@@ -471,7 +471,7 @@ void SaveGameManager::loadCallbacks(const Common::JSONObject &json) {
 	g_engine->_callbacks.clear();
 	if (!json["callbacks"]->isNull()) {
 		const Common::JSONArray &jCallbacks = json["callbacks"]->asArray();
-		for (int i = 0; i < jCallbacks.size(); i++) {
+		for (int i = 0; i < (int)jCallbacks.size(); i++) {
 			const Common::JSONObject &jCallBackHash = jCallbacks[i]->asObject();
 			int id = jCallBackHash["guid"]->asIntegerNumber();
 			float time = ((float)jCallBackHash["time"]->asIntegerNumber()) / 1000.f;
@@ -502,7 +502,7 @@ void SaveGameManager::loadGlobals(const Common::JSONObject &json) {
 }
 
 void SaveGameManager::loadActors(const Common::JSONObject &json) {
-	for (int i = 0; i < g_engine->_actors.size(); i++) {
+	for (int i = 0; i < (int)g_engine->_actors.size(); i++) {
 		Object *a = g_engine->_actors[i];
 		if (a->_key.size() > 0) {
 			loadActor(a, json[a->_key]->asObject());
@@ -522,7 +522,7 @@ void SaveGameManager::loadInventory(const Common::JSONValue *json) {
 				if (jSlot.contains("objects")) {
 					if (jSlot["objects"]->isArray()) {
 						const Common::JSONArray &jSlotObjects = jSlot["objects"]->asArray();
-						for (int j = 0; j < jSlotObjects.size(); j++) {
+						for (int j = 0; j < (int)jSlotObjects.size(); j++) {
 							const Common::JSONValue *jObj = jSlotObjects[j];
 							Object *obj = object(jObj->asString());
 							if (!obj)

--- a/engines/twp/scenegraph.cpp
+++ b/engines/twp/scenegraph.cpp
@@ -79,7 +79,7 @@ const Node *Node::getRoot() const {
 }
 
 int Node::find(Node *other) {
-	for (int i = 0; i < _children.size(); i++) {
+	for (int i = 0; i < (int)_children.size(); i++) {
 		if (_children[i] == other) {
 			return i;
 		}
@@ -96,7 +96,7 @@ void Node::removeChild(Node *child) {
 void Node::clear() {
 	if (_children.size() > 0) {
 		Common::Array<Node *> children(_children);
-		for (int i = 0; i < children.size(); i++) {
+		for (int i = 0; i < (int)children.size(); i++) {
 			children[i]->remove();
 		}
 	}
@@ -139,7 +139,7 @@ void Node::updateColor(Color parentColor) {
 	_computedColor.rgba.g = _color.rgba.g * parentColor.rgba.g;
 	_computedColor.rgba.b = _color.rgba.b * parentColor.rgba.b;
 	onColorUpdated(_computedColor);
-	for (int i = 0; i < _children.size(); i++) {
+	for (int i = 0; i < (int)_children.size(); i++) {
 		Node *child = _children[i];
 		child->updateColor(_computedColor);
 	}
@@ -148,7 +148,7 @@ void Node::updateColor(Color parentColor) {
 void Node::updateAlpha(float parentAlpha) {
 	_computedColor.rgba.a = _color.rgba.a * parentAlpha;
 	onColorUpdated(_computedColor);
-	for (int i = 0; i < _children.size(); i++) {
+	for (int i = 0; i < (int)_children.size(); i++) {
 		Node *child = _children[i];
 		child->updateAlpha(_computedColor.rgba.a);
 	}
@@ -187,7 +187,7 @@ void Node::draw(Math::Matrix4 parent) {
 		Common::Array<Node *> children(_children);
 		Common::sort(children.begin(), children.end(), cmpNodes);
 		drawCore(myTrsf);
-		for (int i = 0; i < children.size(); i++) {
+		for (int i = 0; i < (int)children.size(); i++) {
 			Node *child = children[i];
 			child->draw(trsf);
 		}
@@ -245,7 +245,7 @@ void ParallaxNode::drawCore(Math::Matrix4 trsf) {
 	Texture *texture = g_engine->_resManager.texture(sheet->meta.image);
 	Math::Matrix4 t = trsf;
 	float x = 0.f;
-	for (int i = 0; i < _frames.size(); i++) {
+	for (int i = 0; i < (int)_frames.size(); i++) {
 		const SpriteSheetFrame &frame = sheet->frameTable[_frames[i]];
 		Math::Matrix4 myTrsf = t;
 		myTrsf.translate(Math::Vector3d(x + frame.spriteSourceSize.left, frame.sourceSize.getY() - frame.spriteSourceSize.height() - frame.spriteSourceSize.top, 0.0f));
@@ -278,7 +278,7 @@ void Anim::setAnim(const ObjectAnimation *anim, float fps, bool loop, bool insta
 	if(_obj) setVisible(Twp::find(_obj->_hiddenLayers, _anim->name) == -1);
 
 	clear();
-	for (int i = 0; i < _anim->layers.size(); i++) {
+	for (int i = 0; i < (int)_anim->layers.size(); i++) {
 		const ObjectAnimation &layer = _anim->layers[i];
 		Anim *node = new Anim(_obj);
 		node->setAnim(&layer, fps, loop, instant);
@@ -287,7 +287,7 @@ void Anim::setAnim(const ObjectAnimation *anim, float fps, bool loop, bool insta
 }
 
 void Anim::trigSound() {
-	if ((_anim->triggers.size() > 0) && _frameIndex < _anim->triggers.size()) {
+	if ((_anim->triggers.size() > 0) && _frameIndex < (int)_anim->triggers.size()) {
 		const Common::String &trigger = _anim->triggers[_frameIndex];
 		if ((trigger.size() > 0) && trigger != "null") {
 			_obj->trig(trigger);
@@ -304,7 +304,7 @@ void Anim::update(float elapsed) {
 		_elapsed += elapsed;
 		if (_elapsed > _frameDuration) {
 			_elapsed = 0;
-			if (_frameIndex < _frames.size() - 1) {
+			if (_frameIndex < (int)_frames.size() - 1) {
 				_frameIndex++;
 				trigSound();
 			} else if (_loop) {
@@ -315,7 +315,7 @@ void Anim::update(float elapsed) {
 			}
 		}
 		if (_anim->offsets.size() > 0) {
-			Math::Vector2d off = _frameIndex < _anim->offsets.size() ? _anim->offsets[_frameIndex] : Math::Vector2d();
+			Math::Vector2d off = _frameIndex < (int)_anim->offsets.size() ? _anim->offsets[_frameIndex] : Math::Vector2d();
 			if (_obj->getFacing() == FACE_LEFT) {
 				off.setX(-off.getX());
 			}
@@ -323,7 +323,7 @@ void Anim::update(float elapsed) {
 		}
 	} else if (_children.size() != 0) {
 		bool disabled = true;
-		for (int i = 0; i < _children.size(); i++) {
+		for (int i = 0; i < (int)_children.size(); i++) {
 			Anim *layer = static_cast<Anim *>(_children[i]);
 			layer->update(elapsed);
 			disabled = disabled && layer->_disabled;
@@ -337,7 +337,7 @@ void Anim::update(float elapsed) {
 }
 
 void Anim::drawCore(Math::Matrix4 trsf) {
-	if (_frameIndex < _frames.size()) {
+	if (_frameIndex < (int)_frames.size()) {
 		const Common::String &frame = _frames[_frameIndex];
 		bool flipX = _obj->getFacing() == FACE_LEFT;
 		if (_sheet.size() == 0) {
@@ -497,7 +497,7 @@ static bool hasUpArrow(Object *actor) {
 }
 
 static bool hasDownArrow(Object *actor) {
-	return actor->_inventory.size() > (actor->_inventoryOffset * NUMOBJECTSBYROW + NUMOBJECTS);
+	return (int)actor->_inventory.size() > (actor->_inventoryOffset * NUMOBJECTSBYROW + NUMOBJECTS);
 }
 
 Inventory::Inventory() : Node("Inventory") {
@@ -624,13 +624,13 @@ void Inventory::update(float elapsed, Object *actor, Color backColor, Color verb
 			const Common::Rect &item = _itemRects[i];
 			if (item.contains(scrPos.getX(), scrPos.getY())) {
 				int index = _actor->_inventoryOffset * NUMOBJECTSBYROW + i;
-				if (index < _actor->_inventory.size())
+				if (index < (int)_actor->_inventory.size())
 					_obj = _actor->_inventory[index];
 				break;
 			}
 		}
 
-		for (int i = 0; i < _actor->_inventory.size(); i++) {
+		for (int i = 0; i < (int)_actor->_inventory.size(); i++) {
 			Object *obj = _actor->_inventory[i];
 			obj->update(elapsed);
 		}
@@ -736,9 +736,9 @@ void HotspotMarkerNode::drawCore(Math::Matrix4 trsf) {
 	Texture *texture = g_engine->_resManager.texture(gameSheet->meta.image);
 	SpriteSheetFrame *frame = &gameSheet->frameTable["hotspot_marker"];
 	Color color = Color::create(255, 165, 0);
-	for (int i = 0; i < g_engine->_room->_layers.size(); i++) {
+	for (int i = 0; i < (int)g_engine->_room->_layers.size(); i++) {
 		Layer *layer = g_engine->_room->_layers[i];
-		for (int j = 0; j < layer->_objects.size(); j++) {
+		for (int j = 0; j < (int)layer->_objects.size(); j++) {
 			Object *obj = layer->_objects[j];
 			if (isObject(obj->getId()) && (obj->_objType == otNone) && obj->isTouchable()) {
 				Math::Vector2d pos = g_engine->roomToScreen(obj->_node->getAbsPos());

--- a/engines/twp/squirrel/sqcompiler.cpp
+++ b/engines/twp/squirrel/sqcompiler.cpp
@@ -978,6 +978,7 @@ public:
                     Expect(_SC(':')); Expression();
                     break;
                 }
+                // fallthrough
             default :
                 _fs->AddInstruction(_OP_LOAD, _fs->PushTarget(), _fs->GetConstant(Expect(TK_IDENTIFIER)));
                 Expect(_SC('=')); Expression();

--- a/engines/twp/squirrel/sqlexer.cpp
+++ b/engines/twp/squirrel/sqlexer.cpp
@@ -117,6 +117,7 @@ void SQLexer::LexBlockComment()
             case _SC('*'): { NEXT(); if(CUR_CHAR == _SC('/')) { done = true; NEXT(); }}; continue;
             case _SC('\n'): _currentline++; NEXT(); continue;
             case SQUIRREL_EOB: Error(_SC("missing \"*/\" in comment"));
+            // fallthrough
             default: NEXT();
         }
     }
@@ -207,7 +208,8 @@ SQInteger SQLexer::Lex()
                 RETURN_TOKEN(stype);
             }
             Error(_SC("error parsing the string"));
-                       }
+            return 0;
+            }
         case _SC('"'):
         case _SC('\''): {
             SQInteger stype;
@@ -215,6 +217,7 @@ SQInteger SQLexer::Lex()
                 RETURN_TOKEN(stype);
             }
             Error(_SC("error parsing the string"));
+            return 0;
             }
         case _SC('{'): case _SC('}'): case _SC('('): case _SC(')'): case _SC('['): case _SC(']'):
         case _SC(';'): case _SC(','): case _SC('?'): case _SC('^'): case _SC('~'):

--- a/engines/twp/squirrel/sqobject.cpp
+++ b/engines/twp/squirrel/sqobject.cpp
@@ -512,11 +512,11 @@ bool SQFunctionProto::Load(SQVM *v,SQUserPointer up,SQREADFUNC read,SQObjectPtr 
 
     for(i = 0; i < noutervalues; i++){
         SQUnsignedInteger type;
-        SQObjectPtr name;
+        SQObjectPtr objname;
         _CHECK_IO(SafeRead(v,read,up, &type, sizeof(SQUnsignedInteger)));
         _CHECK_IO(ReadObject(v, up, read, o));
-        _CHECK_IO(ReadObject(v, up, read, name));
-        f->_outervalues[i] = SQOuterVar(name,o, (SQOuterType)type);
+        _CHECK_IO(ReadObject(v, up, read, objname));
+        f->_outervalues[i] = SQOuterVar(objname,o, (SQOuterType)type);
     }
     _CHECK_IO(CheckTag(v,read,up,SQ_CLOSURESTREAM_PART));
 

--- a/engines/twp/squirrel/sqstdrex.cpp
+++ b/engines/twp/squirrel/sqstdrex.cpp
@@ -164,6 +164,7 @@ static SQInteger sqstd_rex_charnode(SQRex *exp,SQBool isclass)
                     exp->_p++;
                     return node;
                 } //else default
+                // fallthrough
             default:
                 t = *exp->_p; exp->_p++;
                 return sqstd_rex_newnode(exp,t);

--- a/engines/twp/squirrel/sqstdstring.cpp
+++ b/engines/twp/squirrel/sqstdstring.cpp
@@ -121,6 +121,7 @@ SQRESULT sqstd_format(HSQUIRRELVM v,SQInteger nformatstringidx,SQInteger *outlen
                 fmt[fpos++] = _SC('\0');
                 }
 #endif
+                // fallthrough
             case 'c':
                 if(SQ_FAILED(sq_getinteger(v,nparam,&ti)))
                     return sq_throwerror(v,_SC("integer expected for the specified format"));

--- a/engines/twp/squirrel/sqvm.cpp
+++ b/engines/twp/squirrel/sqvm.cpp
@@ -236,6 +236,7 @@ bool SQVM::ObjCmp(const SQObjectPtr &o1,const SQObjectPtr &o2,SQInteger &result)
                     return false;
                 }
             }
+            // fallthrough
             //continues through (no break needed)
         default:
             _RET_SUCCEED( _userpointer(o1) < _userpointer(o2)?-1:1 );
@@ -314,6 +315,7 @@ bool SQVM::ToString(const SQObjectPtr &o,SQObjectPtr &res)
                 }
             }
         }
+        // fallthrough
     default:
         scsprintf(_sp(sq_rsl((sizeof(void*)*2)+NUMBER_MAX_CHAR)),sq_rsl((sizeof(void*)*2)+NUMBER_MAX_CHAR),_SC("(%s : 0x%p)"),GetTypeName(o),(void*)_rawval(o));
     }
@@ -573,6 +575,7 @@ bool SQVM::FOREACH_OP(SQObjectPtr &o1,SQObjectPtr &o2,SQObjectPtr
             _generator(o1)->Resume(this, o3);
             _FINISH(0);
         }
+        // fallthrough
     default:
         Raise_Error(_SC("cannot iterate %s"), GetTypeName(o1));
     }
@@ -740,6 +743,7 @@ exception_restore:
                     continue;
                 }
                               }
+                // fallthrough
             case _OP_CALL: {
                     SQObjectPtr clo = STK(arg1);
                     switch (sq_type(clo)) {
@@ -748,7 +752,7 @@ exception_restore:
                         continue;
                     case OT_NATIVECLOSURE: {
                         bool suspend;
-						bool tailcall;
+                        bool tailcall;
                         _GUARD(CallNative(_nativeclosure(clo), arg3, _stackbase+arg2, clo, (SQInt32)sarg0, suspend, tailcall));
                         if(suspend){
                             _suspended = SQTrue;
@@ -789,20 +793,18 @@ exception_restore:
                     case OT_TABLE:
                     case OT_USERDATA:
                     case OT_INSTANCE:{
-                        SQObjectPtr closure;
-                        if(_delegable(clo)->_delegate && _delegable(clo)->GetMetaMethod(this,MT_CALL,closure)) {
+                        SQObjectPtr objclosure;
+                        if(_delegable(clo)->_delegate && _delegable(clo)->GetMetaMethod(this,MT_CALL,objclosure)) {
                             Push(clo);
                             for (SQInteger i = 0; i < arg3; i++) Push(STK(arg2 + i));
-                            if(!CallMetaMethod(closure, MT_CALL, arg3+1, clo)) SQ_THROW();
+                            if(!CallMetaMethod(objclosure, MT_CALL, arg3+1, clo)) SQ_THROW();
                             if(sarg0 != -1) {
                                 STK(arg0) = clo;
                             }
                             break;
                         }
-
-                        //Raise_Error(_SC("attempt to call '%s'"), GetTypeName(clo));
-                        //SQ_THROW();
                       }
+                      // fallthrough
                     default:
                         Raise_Error(_SC("attempt to call '%s'"), GetTypeName(clo));
                         SQ_THROW();
@@ -1076,11 +1078,11 @@ exception_trap:
 
         while( ci ) {
             if(ci->_etraps > 0) {
-                SQExceptionTrap &et = _etraps.top();
-                ci->_ip = et._ip;
-                _top = et._stacksize;
-                _stackbase = et._stackbase;
-                _stack._vals[_stackbase + et._extarget] = currerror;
+                SQExceptionTrap &extrap = _etraps.top();
+                ci->_ip = extrap._ip;
+                _top = extrap._stacksize;
+                _stackbase = extrap._stackbase;
+                _stack._vals[_stackbase + extrap._extarget] = currerror;
                 _etraps.pop_back(); traps--; ci->_etraps--;
                 while(last_top >= _top) _stack._vals[last_top--].Null();
                 goto exception_restore;
@@ -1135,10 +1137,10 @@ void SQVM::CallDebugHook(SQInteger type,SQInteger forcedline)
         _debughook_native(this,type,src,line,fname);
     }
     else {
-        SQObjectPtr temp_reg;
+        SQObjectPtr tmp_reg;
         SQInteger nparams=5;
         Push(_roottable); Push(type); Push(func->_sourcename); Push(forcedline?forcedline:func->GetLine(ci->_ip)); Push(func->_name);
-        Call(_debughook_closure,nparams,_top-nparams,temp_reg,SQFalse);
+        Call(_debughook_closure,nparams,_top-nparams,tmp_reg,SQFalse);
         Pop(nparams);
     }
     _debughook = true;
@@ -1320,7 +1322,7 @@ SQInteger SQVM::FallBackGet(const SQObjectPtr &self,const SQObjectPtr &key,SQObj
         else {
             return FALLBACK_NO_MATCH;
         }
-        //go through
+        // fallthrough
     case OT_INSTANCE: {
         SQObjectPtr closure;
         if(_delegable(self)->GetMetaMethod(this, MT_GET, closure)) {
@@ -1388,7 +1390,7 @@ SQInteger SQVM::FallBackSet(const SQObjectPtr &self,const SQObjectPtr &key,const
         if(_table(self)->_delegate) {
             if(Set(_table(self)->_delegate,key,val,DONT_FALL_BACK)) return FALLBACK_OK;
         }
-        //keps on going
+        // fallthrough
     case OT_INSTANCE:
     case OT_USERDATA:{
         SQObjectPtr closure;
@@ -1418,7 +1420,7 @@ SQInteger SQVM::FallBackSet(const SQObjectPtr &self,const SQObjectPtr &key,const
 
 bool SQVM::Clone(const SQObjectPtr &self,SQObjectPtr &target)
 {
-    SQObjectPtr temp_reg;
+    SQObjectPtr tmp_reg;
     SQObjectPtr newobj;
     switch(sq_type(self)){
     case OT_TABLE:
@@ -1431,7 +1433,7 @@ cloned_mt:
         if(_delegable(newobj)->_delegate && _delegable(newobj)->GetMetaMethod(this,MT_CLONED,closure)) {
             Push(newobj);
             Push(self);
-            if(!CallMetaMethod(closure,MT_CLONED,2,temp_reg))
+            if(!CallMetaMethod(closure,MT_CLONED,2,tmp_reg))
                 return false;
         }
         }
@@ -1740,7 +1742,7 @@ SQObjectPtr &SQVM::GetUp(SQInteger n) { CheckStackAccess(_top+n); return _stack[
 SQObjectPtr &SQVM::GetAt(SQInteger n) { CheckStackAccess(n); return _stack[n]; }
 
 void SQVM::CheckStackAccess(SQInteger n) {
-    if(n < 0 || n >= _stack.size()){
+    if(n < 0 || n >= (SQInteger)_stack.size()){
         std::ostringstream s;
         s << "Stack of the VM accessed with n=" << n << " and stacksize=" << _stack.size();
         //throw std::out_of_range(s.str());

--- a/engines/twp/squtil.cpp
+++ b/engines/twp/squtil.cpp
@@ -256,7 +256,7 @@ void sqcall(const char *name, const Common::Array<HSQOBJECT> &args) {
 	sqpushfunc(v, o, name);
 
 	sq_pushobject(v, o);
-	for (int i = 0; i < args.size(); i++) {
+	for (int i = 0; i < (int)args.size(); i++) {
 		sq_pushobject(v, args[i]);
 	}
 	sq_call(v, 1 + args.size(), SQFalse, SQTrue);
@@ -271,7 +271,7 @@ static int getId(HSQOBJECT table) {
 
 Room *sqroom(HSQOBJECT table) {
 	int id = getId(table);
-	for (int i = 0; i < g_engine->_rooms.size(); i++) {
+	for (int i = 0; i < (int)g_engine->_rooms.size(); i++) {
 		Room *room = g_engine->_rooms[i];
 		if (getId(room->_table) == id)
 			return room;
@@ -288,17 +288,17 @@ Room *sqroom(HSQUIRRELVM v, int i) {
 }
 
 Object *sqobj(int id) {
-	for (int i = 0; i < g_engine->_actors.size(); i++) {
+	for (int i = 0; i < (int)g_engine->_actors.size(); i++) {
 		Object *actor = g_engine->_actors[i];
 		if (getId(actor->_table) == id)
 			return actor;
 	}
 
-	for (int i = 0; i < g_engine->_rooms.size(); i++) {
+	for (int i = 0; i < (int)g_engine->_rooms.size(); i++) {
 		Room *room = g_engine->_rooms[i];
-		for (int j = 0; j < room->_layers.size(); j++) {
+		for (int j = 0; j < (int)room->_layers.size(); j++) {
 			Layer *layer = room->_layers[j];
-			for (int k = 0; k < layer->_objects.size(); k++) {
+			for (int k = 0; k < (int)layer->_objects.size(); k++) {
 				Object *obj = layer->_objects[k];
 				if (getId(obj->_table) == id)
 					return obj;
@@ -321,7 +321,7 @@ Object *sqobj(HSQUIRRELVM v, int i) {
 
 Object *sqactor(HSQOBJECT table) {
 	int id = getId(table);
-	for (int i = 0; i < g_engine->_actors.size(); i++) {
+	for (int i = 0; i < (int)g_engine->_actors.size(); i++) {
 		Object *actor = g_engine->_actors[i];
 		if (actor->getId() == id)
 			return actor;
@@ -337,7 +337,7 @@ Object *sqactor(HSQUIRRELVM v, int i) {
 }
 
 SoundDefinition *sqsounddef(int id) {
-	for (int i = 0; i < g_engine->_audio._soundDefs.size(); i++) {
+	for (int i = 0; i < (int)g_engine->_audio._soundDefs.size(); i++) {
 		SoundDefinition *sound = g_engine->_audio._soundDefs[i];
 		if (sound->getId() == id)
 			return sound;
@@ -403,7 +403,7 @@ ThreadBase *sqthread(int id) {
 		}
 	}
 
-	for (int i = 0; i < g_engine->_threads.size(); i++) {
+	for (int i = 0; i < (int)g_engine->_threads.size(); i++) {
 		ThreadBase *t = g_engine->_threads[i];
 		if (t->getId() == id) {
 			return t;

--- a/engines/twp/squtil.h
+++ b/engines/twp/squtil.h
@@ -23,7 +23,7 @@
 #define TWP_SQUTIL_H
 
 #include "squirrel/squirrel.h"
-#include "utility" // FIXME: Remove usage of standard library i.e. std:: prefixed and replace with Common alternatives
+#include "common/util.h"
 #include "common/str.h"
 #include "twp/twp.h"
 #include "twp/vm.h"
@@ -177,7 +177,7 @@ void sqcall(HSQUIRRELVM v, HSQOBJECT o, const char *name, T... args) {
 
 	sq_pushobject(v, o);
 	if (n > 0) {
-		sqpush(v, std::forward<T>(args)...);
+		sqpush(v, Common::forward<T>(args)...);
 	}
 	sq_call(v, 1 + n, SQFalse, SQTrue);
 	sq_settop(v, top);
@@ -192,7 +192,7 @@ void sqcall(HSQOBJECT o, const char *name, T... args) {
 
 	sq_pushobject(v, o);
 	if (n > 0) {
-		sqpush(v, std::forward<T>(args)...);
+		sqpush(v, Common::forward<T>(args)...);
 	}
 	sq_call(v, 1 + n, SQFalse, SQTrue);
 	sq_settop(v, top);
@@ -208,7 +208,7 @@ void sqcall(const char *name, T... args) {
 
 	sq_pushobject(v, o);
 	if (n > 0) {
-		sqpush(v, std::forward<T>(args)...);
+		sqpush(v, Common::forward<T>(args)...);
 	}
 	sq_call(v, 1 + n, SQFalse, SQTrue);
 	sq_settop(v, top);
@@ -229,7 +229,7 @@ void sqcallfunc(TResult &result, HSQOBJECT o, const char *name, T... args) {
 	sq_remove(v, -2);
 
 	sqpush(v, o);
-	sqpush(v, std::forward<T>(args)...);
+	sqpush(v, Common::forward<T>(args)...);
 	if (SQ_FAILED(sq_call(v, n + 1, SQTrue, SQTrue))) {
 		// sqstd_printcallstack(v);
 		sq_settop(v, top);
@@ -256,7 +256,7 @@ void sqcallfunc(TResult &result, const char *name, T... args) {
 	sq_remove(v, -2);
 
 	sqpush(v, o);
-	sqpush(v, std::forward<T>(args)...);
+	sqpush(v, Common::forward<T>(args)...);
 	if (SQ_FAILED(sq_call(v, n + 1, SQTrue, SQTrue))) {
 		// sqstd_printcallstack(v);
 		sq_settop(v, top);

--- a/engines/twp/squtil.h
+++ b/engines/twp/squtil.h
@@ -23,6 +23,7 @@
 #define TWP_SQUTIL_H
 
 #include "squirrel/squirrel.h"
+#include "utility" // FIXME: Remove usage of standard library i.e. std:: prefixed and replace with Common alternatives
 #include "common/str.h"
 #include "twp/twp.h"
 #include "twp/vm.h"

--- a/engines/twp/syslib.cpp
+++ b/engines/twp/syslib.cpp
@@ -180,13 +180,13 @@ static SQInteger breakhere(HSQUIRRELVM v) {
 		int numFrames;
 		if (SQ_FAILED(sqget(v, 2, numFrames)))
 			return sq_throwerror(v, "failed to get numFrames");
-		return breakfunc(v, [&](ThreadBase *t) { ((Thread *)t)->_numFrames = numFrames; });
+		return breakfunc(v, [&](ThreadBase *tb) { ((Thread *)tb)->_numFrames = numFrames; });
 	}
 	if (t == OT_FLOAT) {
 		float time;
 		if (SQ_FAILED(sqget(v, 2, time)))
 			return sq_throwerror(v, "failed to get time");
-		return breakfunc(v, [&](ThreadBase *t) { ((Thread *)t)->_waitTime = time; });
+		return breakfunc(v, [&](ThreadBase *tb) { ((Thread *)tb)->_waitTime = time; });
 	}
 	return sq_throwerror(v, Common::String::format("failed to get numFrames (wrong type = {%d})", t).c_str());
 }
@@ -633,7 +633,7 @@ static SQInteger removeCallback(HSQUIRRELVM v) {
 	int id = 0;
 	if (SQ_FAILED(sqget(v, 2, id)))
 		return sq_throwerror(v, "failed to get callback");
-	for (int i = 0; i < g_engine->_callbacks.size(); i++) {
+	for (int i = 0; i < (int)g_engine->_callbacks.size(); i++) {
 		Callback *cb = g_engine->_callbacks[i];
 		if (cb->getId() == id) {
 			g_engine->_callbacks.remove_at(i);

--- a/engines/twp/thread.cpp
+++ b/engines/twp/thread.cpp
@@ -59,7 +59,7 @@ Thread::Thread(const Common::String &name, bool global, HSQOBJECT threadObj, HSQ
 	_pauseable = true;
 
 	HSQUIRRELVM v = g_engine->getVm();
-	for (int i = 0; i < _args.size(); i++) {
+	for (int i = 0; i < (int)_args.size(); i++) {
 		sq_addref(v, &_args[i]);
 	}
 	sq_addref(v, &_threadObj);
@@ -70,7 +70,7 @@ Thread::Thread(const Common::String &name, bool global, HSQOBJECT threadObj, HSQ
 Thread::~Thread() {
 	debug("delete thread %d, %s, global: %s", _id, _name.c_str(), _global ? "yes" : "no");
 	HSQUIRRELVM v = g_engine->getVm();
-	for (int i = 0; i < _args.size(); i++) {
+	for (int i = 0; i < (int)_args.size(); i++) {
 		sq_release(v, &_args[i]);
 	}
 	sq_release(v, &_threadObj);
@@ -84,7 +84,7 @@ bool Thread::call() {
 	SQInteger top = sq_gettop(v);
 	sq_pushobject(v, _closureObj);
 	sq_pushobject(v, _envObj);
-	for (int i = 0; i < _args.size(); i++) {
+	for (int i = 0; i < (int)_args.size(); i++) {
 		sq_pushobject(v, _args[i]);
 	}
 	if (SQ_FAILED(sq_call(v, 1 + _args.size(), SQFalse, SQTrue))) {
@@ -131,7 +131,7 @@ Cutscene::Cutscene(HSQUIRRELVM v, HSQOBJECT threadObj, HSQOBJECT closure, HSQOBJ
 	debug("Create cutscene %d with input: 0x%X", _id, _inputState);
 	g_engine->_inputState.setInputActive(false);
 	g_engine->_inputState.setShowCursor(false);
-	for (int i = 0; i < g_engine->_threads.size(); i++) {
+	for (int i = 0; i < (int)g_engine->_threads.size(); i++) {
 		ThreadBase *thread = g_engine->_threads[i];
 		if (thread->isGlobal())
 			thread->pause();
@@ -175,7 +175,7 @@ void Cutscene::stop() {
 	debug("Restore cutscene input: %X", _inputState);
 	g_engine->follow(g_engine->_actor);
 	Common::Array<ThreadBase *> threads(g_engine->_threads);
-	for (int i = 0; i < threads.size(); i++) {
+	for (int i = 0; i < (int)threads.size(); i++) {
 		ThreadBase *thread = threads[i];
 		if (thread->isGlobal())
 			thread->unpause();
@@ -230,6 +230,8 @@ bool Cutscene::update(float elapsed) {
 	case csQuit:
 		return true;
 	}
+
+	return false;
 }
 
 bool Cutscene::hasOverride() const {

--- a/engines/twp/twp.cpp
+++ b/engines/twp/twp.cpp
@@ -287,9 +287,9 @@ template<typename TFunc>
 void objsAt(Math::Vector2d pos, TFunc func) {
 	if (g_engine->_uiInv.getObject() && g_engine->_room->_fullscreen == FULLSCREENROOM)
 		func(g_engine->_uiInv.getObject());
-	for (int i = 0; i < g_engine->_room->_layers.size(); i++) {
+	for (int i = 0; i < (int)g_engine->_room->_layers.size(); i++) {
 		Layer *layer = g_engine->_room->_layers[i];
-		for (int j = 0; j < layer->_objects.size(); j++) {
+		for (int j = 0; j < (int)layer->_objects.size(); j++) {
 			Object *obj = layer->_objects[j];
 			if ((obj != g_engine->_actor) && (obj->isTouchable() || obj->inInventory()) && (obj->_node->isVisible()) && (obj->_objType == otNone) && (obj->contains(pos)))
 				if (func(obj))
@@ -311,7 +311,7 @@ Object *inventoryAt(Math::Vector2d pos) {
 }
 
 static void selectSlotActor(int id) {
-	for (int i = 0; i < g_engine->_actors.size(); i++) {
+	for (int i = 0; i < (int)g_engine->_actors.size(); i++) {
 		if (g_engine->_actors[i]->getId() == id) {
 			g_engine->setActor(g_engine->_actors[i]);
 			break;
@@ -745,7 +745,7 @@ Common::Error TwpEngine::run() {
 							}
 						}
 						int index = find(actors, _actor) + 1;
-						if (index >= actors.size())
+						if (index >= (int)actors.size())
 							index -= actors.size();
 						setActor(actors[index], true);
 					}
@@ -909,7 +909,7 @@ Room *TwpEngine::defineRoom(const Common::String &name, HSQOBJECT table, bool ps
 		result->load(entry);
 		result->_name = name;
 		result->_pseudo = pseudo;
-		for (int i = 0; i < result->_layers.size(); i++) {
+		for (int i = 0; i < (int)result->_layers.size(); i++) {
 			Layer *layer = result->_layers[i];
 			// create layer node
 			ParallaxNode *layerNode = new ParallaxNode(layer->_parallax, result->_sheet, layer->_names);
@@ -918,7 +918,7 @@ Room *TwpEngine::defineRoom(const Common::String &name, HSQOBJECT table, bool ps
 			layer->_node = layerNode;
 			result->_scene->addChild(layerNode);
 
-			for (int j = 0; j < layer->_objects.size(); j++) {
+			for (int j = 0; j < (int)layer->_objects.size(); j++) {
 				Object *obj = layer->_objects[j];
 				if (!sqrawexists(table, obj->_key)) {
 					// this object does not exist, so create it
@@ -948,9 +948,9 @@ Room *TwpEngine::defineRoom(const Common::String &name, HSQOBJECT table, bool ps
 	}
 
 	// assign parent node
-	for (int i = 0; i < result->_layers.size(); i++) {
+	for (int i = 0; i < (int)result->_layers.size(); i++) {
 		Layer *layer = result->_layers[i];
-		for (int j = 0; j < layer->_objects.size(); j++) {
+		for (int j = 0; j < (int)layer->_objects.size(); j++) {
 			Object *obj = layer->_objects[j];
 			if (obj->_parent.size() > 0) {
 				Object *parent = result->getObj(obj->_parent);
@@ -1085,9 +1085,9 @@ void TwpEngine::enterRoom(Room *room, Object *door) {
 
 	// call actor enter function and objects enter function
 	actorEnter();
-	for (int i = 0; i < room->_layers.size(); i++) {
+	for (int i = 0; i < (int)room->_layers.size(); i++) {
 		Layer *layer = room->_layers[i];
-		for (int j = 0; j < layer->_objects.size(); j++) {
+		for (int j = 0; j < (int)layer->_objects.size(); j++) {
 			Object *obj = layer->_objects[j];
 			// add all scaling triggers
 			if (obj->_objType == ObjectType::otTrigger) {
@@ -1148,9 +1148,9 @@ void TwpEngine::exitRoom(Room *nextRoom) {
 		}
 
 		// delete all temporary objects
-		for (int i = 0; i < _room->_layers.size(); i++) {
+		for (int i = 0; i < (int)_room->_layers.size(); i++) {
 			Layer *layer = _room->_layers[i];
-			for (int j = 0; j < layer->_objects.size(); j++) {
+			for (int j = 0; j < (int)layer->_objects.size(); j++) {
 				Object *obj = layer->_objects[j];
 				if (obj->_temporary) {
 					delete obj;
@@ -1164,7 +1164,7 @@ void TwpEngine::exitRoom(Room *nextRoom) {
 		sqcall("exitedRoom", _room->_table);
 
 		// stop all local threads
-		for (int i = 0; i < _threads.size(); i++) {
+		for (int i = 0; i < (int)_threads.size(); i++) {
 			ThreadBase *thread = _threads[i];
 			if (!thread->isGlobal()) {
 				thread->stop();
@@ -1448,7 +1448,7 @@ void TwpEngine::callTrigger(Object *obj, HSQOBJECT trigger) {
 void TwpEngine::updateTriggers() {
 	if (_actor) {
 		// check if actor enters or leaves an object trigger
-		for (int i = 0; i < _room->_triggers.size(); i++) {
+		for (int i = 0; i < (int)_room->_triggers.size(); i++) {
 			Object *trigger = _room->_triggers[i];
 			if (!trigger->_triggerActive && trigger->contains(_actor->_node->getAbsPos())) {
 				debug("call enter trigger %s", trigger->_name.c_str());
@@ -1462,7 +1462,7 @@ void TwpEngine::updateTriggers() {
 		}
 
 		// check if actor enters or leaves a scaling trigger
-		for (int i = 0; i < _room->_scalingTriggers.size(); i++) {
+		for (int i = 0; i < (int)_room->_scalingTriggers.size(); i++) {
 			ScalingTrigger *trigger = &_room->_scalingTriggers[i];
 			if (trigger->_obj->_triggerActive && !trigger->_obj->contains(_actor->_node->getAbsPos())) {
 				debug("leave scaling trigger %s", trigger->_obj->_key.c_str());
@@ -1470,7 +1470,7 @@ void TwpEngine::updateTriggers() {
 				_room->_scaling = _room->_scalings[0];
 			}
 		}
-		for (int i = 0; i < _room->_scalingTriggers.size(); i++) {
+		for (int i = 0; i < (int)_room->_scalingTriggers.size(); i++) {
 			ScalingTrigger *trigger = &_room->_scalingTriggers[i];
 			if (!trigger->_obj->_triggerActive && trigger->_obj->contains(_actor->_node->getAbsPos())) {
 				debug("enter scaling trigger %s", trigger->_obj->_key.c_str());
@@ -1510,7 +1510,7 @@ void TwpEngine::skipCutscene() {
 }
 
 Scaling *TwpEngine::getScaling(const Common::String &name) {
-	for (int i = 0; i < _room->_scalings.size(); i++) {
+	for (int i = 0; i < (int)_room->_scalings.size(); i++) {
 		Scaling *scaling = &_room->_scalings[i];
 		if (scaling->trigger == name) {
 			return scaling;

--- a/engines/twp/util.cpp
+++ b/engines/twp/util.cpp
@@ -41,6 +41,7 @@ Facing flip(Facing facing) {
 	switch (facing) {
 	case FACE_BACK:
 		return FACE_FRONT;
+	default:
 	case FACE_FRONT:
 		return FACE_BACK;
 	case FACE_LEFT:
@@ -160,7 +161,7 @@ Common::String join(const Common::Array<Common::String> &array, const Common::St
 	Common::String result;
 	if (array.size() > 0) {
 		result += array[0];
-		for (int i = 1; i < array.size(); i++) {
+		for (int i = 1; i < (int)array.size(); i++) {
 			result += (sep + array[i]);
 		}
 	}

--- a/engines/twp/util.h
+++ b/engines/twp/util.h
@@ -60,7 +60,7 @@ void parseObjectAnimations(const Common::JSONArray &jAnims, Common::Array<Object
 // array util
 template<typename T>
 int find(const Common::Array<T>& array, const T& o) {
-	for (int i = 0; i < array.size(); i++) {
+	for (int i = 0; i < (int)array.size(); i++) {
 		if (array[i] == o) {
 			return i;
 		}

--- a/engines/twp/walkboxnode.cpp
+++ b/engines/twp/walkboxnode.cpp
@@ -91,7 +91,7 @@ PathNode::PathNode() : Node("Path") {
 }
 
 Math::Vector2d PathNode::fixPos(Math::Vector2d pos) {
-	for (int i = 0; i < g_engine->_room->_mergedPolygon.size(); i++) {
+	for (int i = 0; i < (int)g_engine->_room->_mergedPolygon.size(); i++) {
 		Walkbox &wb = g_engine->_room->_mergedPolygon[i];
 		if (!wb.isVisible() && wb.contains(pos)) {
 			return wb.getClosestPointOnEdge(pos);


### PR DESCRIPTION
These changes fix various GCC compiler warnings, mainly from signed vs. unsigned comparison due to the size() call of Common::Array returning a local size_type, which is unsigned so need to cast this to int. Apart from these, there are a number of undeclared fallthroughs in switch statements which should be reviewed and missing return of values from functions which return non-void (these are the default statements added to switch statements). There is one remaining usage of C++-20 which has been removed.

Apart from these fixes, there is still quite a bit of usage of std library, rather than ScummVM OSystem Common. This needs to be migrated for portability, along with removal of any FORBIDDEN symbol usage.

The remaining warnings should also be addressed, but are harder to fix and/or need major changes. Since this engine is still in development, I have refrained from making large changes.

The remaining warnings are as follows:
````
In file included from engines/twp/squirrel/sqapi.cpp:5:
engines/twp/squirrel/sqvm.h: In copy constructor ‘SQExceptionTrap::SQExceptionTrap(const SQExceptionTrap&)’:
engines/twp/squirrel/sqvm.h:23:60: warning: implicitly-declared ‘SQExceptionTrap& SQExceptionTrap::operator=(const SQExceptionTrap&)’ is deprecated [-Wdeprecated-copy]
     SQExceptionTrap(const SQExceptionTrap &et) { (*this) = et;  }
                                                            ^~
engines/twp/squirrel/sqvm.h:23:5: note: because ‘SQExceptionTrap’ has user-provided ‘SQExceptionTrap::SQExceptionTrap(const SQExceptionTrap&)’
     SQExceptionTrap(const SQExceptionTrap &et) { (*this) = et;  }
     ^~~~~~~~~~~~~~~
In file included from engines/twp/squirrel/sqobject.h:5,
                 from engines/twp/squirrel/sqpcheader.h:17,
                 from engines/twp/squirrel/sqapi.cpp:4:
engines/twp/squirrel/squtils.h: In instantiation of ‘void sqvector<T>::remove(SQUnsignedInteger) [with T = SQObjectPtr; SQUnsignedInteger = long long unsigned int]’:
engines/twp/squirrel/sqarray.h:83:23:   required from here
engines/twp/squirrel/squtils.h:97:20: warning: ‘void* memmove(void*, const void*, size_t)’ writing to an object of type ‘struct SQObjectPtr’ with no trivial copy-assignment; use copy-assignment or copy-initialization instead [-Wclass-memaccess]
             memmove(&_vals[idx], &_vals[idx+1], sizeof(T) * (_size - idx - 1));
             ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
engines/twp/squirrel/sqobject.h:205:8: note: ‘struct SQObjectPtr’ declared here
 struct SQObjectPtr : public SQObject
        ^~~~~~~~~~~
In file included from engines/twp/squirrel/sqbaselib.cpp:5:
engines/twp/squirrel/sqvm.h: In copy constructor ‘SQExceptionTrap::SQExceptionTrap(const SQExceptionTrap&)’:
engines/twp/squirrel/sqvm.h:23:60: warning: implicitly-declared ‘SQExceptionTrap& SQExceptionTrap::operator=(const SQExceptionTrap&)’ is deprecated [-Wdeprecated-copy]
     SQExceptionTrap(const SQExceptionTrap &et) { (*this) = et;  }
                                                            ^~
engines/twp/squirrel/sqvm.h:23:5: note: because ‘SQExceptionTrap’ has user-provided ‘SQExceptionTrap::SQExceptionTrap(const SQExceptionTrap&)’
     SQExceptionTrap(const SQExceptionTrap &et) { (*this) = et;  }
     ^~~~~~~~~~~~~~~
In file included from engines/twp/squirrel/sqobject.h:5,
                 from engines/twp/squirrel/sqpcheader.h:17,
                 from engines/twp/squirrel/sqbaselib.cpp:4:
engines/twp/squirrel/squtils.h: In instantiation of ‘void sqvector<T>::remove(SQUnsignedInteger) [with T = SQObjectPtr; SQUnsignedInteger = long long unsigned int]’:
engines/twp/squirrel/sqarray.h:83:23:   required from here
engines/twp/squirrel/squtils.h:97:20: warning: ‘void* memmove(void*, const void*, size_t)’ writing to an object of type ‘struct SQObjectPtr’ with no trivial copy-assignment; use copy-assignment or copy-initialization instead [-Wclass-memaccess]
             memmove(&_vals[idx], &_vals[idx+1], sizeof(T) * (_size - idx - 1));
             ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
engines/twp/squirrel/sqobject.h:205:8: note: ‘struct SQObjectPtr’ declared here
 struct SQObjectPtr : public SQObject
        ^~~~~~~~~~~
engines/twp/squirrel/sqfuncstate.cpp: In member function ‘SQFunctionProto* SQFuncState::BuildProto()’:
engines/twp/squirrel/sqfuncstate.cpp:618:104: warning: implicitly-declared ‘SQOuterVar& SQOuterVar::operator=(const SQOuterVar&)’ is deprecated [-Wdeprecated-copy]
     for(SQUnsignedInteger no = 0; no < _outervalues.size(); no++) f->_outervalues[no] = _outervalues[no];
                                                                                                        ^
In file included from engines/twp/squirrel/sqfuncstate.cpp:8:
engines/twp/squirrel/sqfuncproto.h:22:5: note: because ‘SQOuterVar’ has user-provided ‘SQOuterVar::SQOuterVar(const SQOuterVar&)’
     SQOuterVar(const SQOuterVar &ov)
     ^~~~~~~~~~
engines/twp/squirrel/sqfuncstate.cpp:619:110: warning: implicitly-declared ‘SQLocalVarInfo& SQLocalVarInfo::operator=(const SQLocalVarInfo&)’ is deprecated [-Wdeprecated-copy]
     for(SQUnsignedInteger nl = 0; nl < _localvarinfos.size(); nl++) f->_localvarinfos[nl] = _localvarinfos[nl];
                                                                                                              ^
engines/twp/squirrel/sqfuncproto.h:36:5: note: because ‘SQLocalVarInfo’ has user-provided ‘SQLocalVarInfo::SQLocalVarInfo(const SQLocalVarInfo&)’
     SQLocalVarInfo(const SQLocalVarInfo &lvi)
     ^~~~~~~~~~~~~~
In file included from engines/twp/squirrel/sqdebug.cpp:6:
engines/twp/squirrel/sqvm.h: In copy constructor ‘SQExceptionTrap::SQExceptionTrap(const SQExceptionTrap&)’:
engines/twp/squirrel/sqvm.h:23:60: warning: implicitly-declared ‘SQExceptionTrap& SQExceptionTrap::operator=(const SQExceptionTrap&)’ is deprecated [-Wdeprecated-copy]
     SQExceptionTrap(const SQExceptionTrap &et) { (*this) = et;  }
                                                            ^~
engines/twp/squirrel/sqvm.h:23:5: note: because ‘SQExceptionTrap’ has user-provided ‘SQExceptionTrap::SQExceptionTrap(const SQExceptionTrap&)’
     SQExceptionTrap(const SQExceptionTrap &et) { (*this) = et;  }
     ^~~~~~~~~~~~~~~
In file included from engines/twp/squirrel/sqobject.cpp:5:
engines/twp/squirrel/sqvm.h: In copy constructor ‘SQExceptionTrap::SQExceptionTrap(const SQExceptionTrap&)’:
engines/twp/squirrel/sqvm.h:23:60: warning: implicitly-declared ‘SQExceptionTrap& SQExceptionTrap::operator=(const SQExceptionTrap&)’ is deprecated [-Wdeprecated-copy]
     SQExceptionTrap(const SQExceptionTrap &et) { (*this) = et;  }
                                                            ^~
engines/twp/squirrel/sqvm.h:23:5: note: because ‘SQExceptionTrap’ has user-provided ‘SQExceptionTrap::SQExceptionTrap(const SQExceptionTrap&)’
     SQExceptionTrap(const SQExceptionTrap &et) { (*this) = et;  }
     ^~~~~~~~~~~~~~~
engines/twp/squirrel/sqobject.cpp: In static member function ‘static bool SQFunctionProto::Load(SQVM*, SQUserPointer, SQREADFUNC, SQObjectPtr&)’:
engines/twp/squirrel/sqobject.cpp:519:69: warning: implicitly-declared ‘SQOuterVar& SQOuterVar::operator=(const SQOuterVar&)’ is deprecated [-Wdeprecated-copy]
         f->_outervalues[i] = SQOuterVar(objname,o, (SQOuterType)type);
                                                                     ^
In file included from engines/twp/squirrel/sqobject.cpp:10:
engines/twp/squirrel/sqfuncproto.h:22:5: note: because ‘SQOuterVar’ has user-provided ‘SQOuterVar::SQOuterVar(const SQOuterVar&)’
     SQOuterVar(const SQOuterVar &ov)
     ^~~~~~~~~~
engines/twp/squirrel/sqobject.cpp:529:32: warning: implicitly-declared ‘SQLocalVarInfo& SQLocalVarInfo::operator=(const SQLocalVarInfo&)’ is deprecated [-Wdeprecated-copy]
         f->_localvarinfos[i] = lvi;
                                ^~~
engines/twp/squirrel/sqfuncproto.h:36:5: note: because ‘SQLocalVarInfo’ has user-provided ‘SQLocalVarInfo::SQLocalVarInfo(const SQLocalVarInfo&)’
     SQLocalVarInfo(const SQLocalVarInfo &lvi)
     ^~~~~~~~~~~~~~
In file included from engines/twp/squirrel/sqobject.h:5,
                 from engines/twp/squirrel/sqpcheader.h:17,
                 from engines/twp/squirrel/sqobject.cpp:4:
engines/twp/squirrel/squtils.h: In instantiation of ‘void sqvector<T>::remove(SQUnsignedInteger) [with T = SQObjectPtr; SQUnsignedInteger = long long unsigned int]’:
engines/twp/squirrel/sqarray.h:83:23:   required from here
engines/twp/squirrel/squtils.h:97:20: warning: ‘void* memmove(void*, const void*, size_t)’ writing to an object of type ‘struct SQObjectPtr’ with no trivial copy-assignment; use copy-assignment or copy-initialization instead [-Wclass-memaccess]
             memmove(&_vals[idx], &_vals[idx+1], sizeof(T) * (_size - idx - 1));
             ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
engines/twp/squirrel/sqobject.h:205:8: note: ‘struct SQObjectPtr’ declared here
 struct SQObjectPtr : public SQObject
        ^~~~~~~~~~~
In file included from engines/twp/squirrel/sqcompiler.cpp:14:
engines/twp/squirrel/sqvm.h: In copy constructor ‘SQExceptionTrap::SQExceptionTrap(const SQExceptionTrap&)’:
engines/twp/squirrel/sqvm.h:23:60: warning: implicitly-declared ‘SQExceptionTrap& SQExceptionTrap::operator=(const SQExceptionTrap&)’ is deprecated [-Wdeprecated-copy]
     SQExceptionTrap(const SQExceptionTrap &et) { (*this) = et;  }
                                                            ^~
engines/twp/squirrel/sqvm.h:23:5: note: because ‘SQExceptionTrap’ has user-provided ‘SQExceptionTrap::SQExceptionTrap(const SQExceptionTrap&)’
     SQExceptionTrap(const SQExceptionTrap &et) { (*this) = et;  }
     ^~~~~~~~~~~~~~~
In file included from engines/twp/squirrel/sqstate.cpp:6:
engines/twp/squirrel/sqvm.h: In copy constructor ‘SQExceptionTrap::SQExceptionTrap(const SQExceptionTrap&)’:
engines/twp/squirrel/sqvm.h:23:60: warning: implicitly-declared ‘SQExceptionTrap& SQExceptionTrap::operator=(const SQExceptionTrap&)’ is deprecated [-Wdeprecated-copy]
     SQExceptionTrap(const SQExceptionTrap &et) { (*this) = et;  }
                                                            ^~
engines/twp/squirrel/sqvm.h:23:5: note: because ‘SQExceptionTrap’ has user-provided ‘SQExceptionTrap::SQExceptionTrap(const SQExceptionTrap&)’
     SQExceptionTrap(const SQExceptionTrap &et) { (*this) = et;  }
     ^~~~~~~~~~~~~~~
In file included from engines/twp/squirrel/sqobject.h:5,
                 from engines/twp/squirrel/sqpcheader.h:17,
                 from engines/twp/squirrel/sqstate.cpp:4:
engines/twp/squirrel/squtils.h: In instantiation of ‘void sqvector<T>::remove(SQUnsignedInteger) [with T = SQObjectPtr; SQUnsignedInteger = long long unsigned int]’:
engines/twp/squirrel/sqarray.h:83:23:   required from here
engines/twp/squirrel/squtils.h:97:20: warning: ‘void* memmove(void*, const void*, size_t)’ writing to an object of type ‘struct SQObjectPtr’ with no trivial copy-assignment; use copy-assignment or copy-initialization instead [-Wclass-memaccess]
             memmove(&_vals[idx], &_vals[idx+1], sizeof(T) * (_size - idx - 1));
             ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
engines/twp/squirrel/sqobject.h:205:8: note: ‘struct SQObjectPtr’ declared here
 struct SQObjectPtr : public SQObject
        ^~~~~~~~~~~
In file included from engines/twp/squirrel/sqtable.cpp:5:
engines/twp/squirrel/sqvm.h: In copy constructor ‘SQExceptionTrap::SQExceptionTrap(const SQExceptionTrap&)’:
engines/twp/squirrel/sqvm.h:23:60: warning: implicitly-declared ‘SQExceptionTrap& SQExceptionTrap::operator=(const SQExceptionTrap&)’ is deprecated [-Wdeprecated-copy]
     SQExceptionTrap(const SQExceptionTrap &et) { (*this) = et;  }
                                                            ^~
engines/twp/squirrel/sqvm.h:23:5: note: because ‘SQExceptionTrap’ has user-provided ‘SQExceptionTrap::SQExceptionTrap(const SQExceptionTrap&)’
     SQExceptionTrap(const SQExceptionTrap &et) { (*this) = et;  }
     ^~~~~~~~~~~~~~~
In file included from engines/twp/squirrel/sqvm.cpp:10:
engines/twp/squirrel/sqvm.h: In copy constructor ‘SQExceptionTrap::SQExceptionTrap(const SQExceptionTrap&)’:
engines/twp/squirrel/sqvm.h:23:60: warning: implicitly-declared ‘SQExceptionTrap& SQExceptionTrap::operator=(const SQExceptionTrap&)’ is deprecated [-Wdeprecated-copy]
     SQExceptionTrap(const SQExceptionTrap &et) { (*this) = et;  }
                                                            ^~
engines/twp/squirrel/sqvm.h:23:5: note: because ‘SQExceptionTrap’ has user-provided ‘SQExceptionTrap::SQExceptionTrap(const SQExceptionTrap&)’
     SQExceptionTrap(const SQExceptionTrap &et) { (*this) = et;  }
     ^~~~~~~~~~~~~~~
In file included from engines/twp/squirrel/sqobject.h:5,
                 from engines/twp/squirrel/sqpcheader.h:17,
                 from engines/twp/squirrel/sqvm.cpp:4:
engines/twp/squirrel/squtils.h: In instantiation of ‘void sqvector<T>::remove(SQUnsignedInteger) [with T = SQObjectPtr; SQUnsignedInteger = long long unsigned int]’:
engines/twp/squirrel/sqarray.h:83:23:   required from here
engines/twp/squirrel/squtils.h:97:20: warning: ‘void* memmove(void*, const void*, size_t)’ writing to an object of type ‘struct SQObjectPtr’ with no trivial copy-assignment; use copy-assignment or copy-initialization instead [-Wclass-memaccess]
             memmove(&_vals[idx], &_vals[idx+1], sizeof(T) * (_size - idx - 1));
             ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
engines/twp/squirrel/sqobject.h:205:8: note: ‘struct SQObjectPtr’ declared here
 struct SQObjectPtr : public SQObject
        ^~~~~~~~~~~
In file included from engines/twp/squirrel/sqclass.cpp:5:
engines/twp/squirrel/sqvm.h: In copy constructor ‘SQExceptionTrap::SQExceptionTrap(const SQExceptionTrap&)’:
engines/twp/squirrel/sqvm.h:23:60: warning: implicitly-declared ‘SQExceptionTrap& SQExceptionTrap::operator=(const SQExceptionTrap&)’ is deprecated [-Wdeprecated-copy]
     SQExceptionTrap(const SQExceptionTrap &et) { (*this) = et;  }
                                                            ^~
engines/twp/squirrel/sqvm.h:23:5: note: because ‘SQExceptionTrap’ has user-provided ‘SQExceptionTrap::SQExceptionTrap(const SQExceptionTrap&)’
     SQExceptionTrap(const SQExceptionTrap &et) { (*this) = et;  }
     ^~~~~~~~~~~~~~~
engines/twp/clipper/clipper.cpp: In function ‘ClipperLib::Int128 ClipperLib::Int128Mul(long64, long64)’:
engines/twp/clipper/clipper.cpp:361:12: warning: implicitly-declared ‘ClipperLib::Int128& ClipperLib::Int128::operator=(const ClipperLib::Int128&)’ is deprecated [-Wdeprecated-copy]
     tmp = -tmp;
            ^~~
engines/twp/clipper/clipper.cpp:254:3: note: because ‘ClipperLib::Int128’ has user-provided ‘ClipperLib::Int128::Int128(const ClipperLib::Int128&)’
   Int128(const Int128 &val) : lo(val.lo), hi(val.hi) {}
   ^~~~~~
engines/twp/clipper/clipper.cpp: In function ‘void ClipperLib::InitEdge(TEdge*, TEdge*, TEdge*, const IntPoint&)’:
engines/twp/clipper/clipper.cpp:677:14: warning: ‘void* memset(void*, int, size_t)’ clearing an object of non-trivial type ‘struct ClipperLib::TEdge’; use assignment or value-initialization instead [-Wclass-memaccess]
   std::memset(e, 0, sizeof(TEdge));
   ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
engines/twp/clipper/clipper.cpp:68:8: note: ‘struct ClipperLib::TEdge’ declared here
 struct TEdge {
        ^~~~~
In file included from engines/twp/vm.cpp:33:
engines/twp/squirrel/sqvm.h: In copy constructor ‘SQExceptionTrap::SQExceptionTrap(const SQExceptionTrap&)’:
engines/twp/squirrel/sqvm.h:23:60: warning: implicitly-declared ‘SQExceptionTrap& SQExceptionTrap::operator=(const SQExceptionTrap&)’ is deprecated [-Wdeprecated-copy]
     SQExceptionTrap(const SQExceptionTrap &et) { (*this) = et;  }
                                                            ^~
engines/twp/squirrel/sqvm.h:23:5: note: because ‘SQExceptionTrap’ has user-provided ‘SQExceptionTrap::SQExceptionTrap(const SQExceptionTrap&)’
     SQExceptionTrap(const SQExceptionTrap &et) { (*this) = et;  }
     ^~~~~~~~~~~~~~~
engines/twp/font.cpp: In member function ‘void Twp::Text::update()’:
engines/twp/font.cpp:313:65: warning: format ‘%x’ expects argument of type ‘unsigned int*’, but argument 3 has type ‘int*’ [-Wformat=]
                                         sscanf(s.c_str() + 1, "%x", &iColor);
                                                                ~^   ~~~~~~~
                                                                 |   |
                                                                 |   int*
                                                                 unsigned int*
                                                                %x
In file included from engines/twp/syslib.cpp:31:
./engines/twp/squirrel/sqvm.h: In copy constructor ‘SQExceptionTrap::SQExceptionTrap(const SQExceptionTrap&)’:
./engines/twp/squirrel/sqvm.h:23:60: warning: implicitly-declared ‘SQExceptionTrap& SQExceptionTrap::operator=(const SQExceptionTrap&)’ is deprecated [-Wdeprecated-copy]
     SQExceptionTrap(const SQExceptionTrap &et) { (*this) = et;  }
                                                            ^~
./engines/twp/squirrel/sqvm.h:23:5: note: because ‘SQExceptionTrap’ has user-provided ‘SQExceptionTrap::SQExceptionTrap(const SQExceptionTrap&)’
     SQExceptionTrap(const SQExceptionTrap &et) { (*this) = et;  }
     ^~~~~~~~~~~~~~~
In file included from ./engines/twp/util.h:25,
                 from ./engines/twp/motor.h:28,
                 from ./engines/twp/room.h:31,
                 from ./engines/twp/shaders.h:25,
                 from ./engines/twp/twp.h:36,
                 from engines/twp/syslib.cpp:23:
engines/twp/syslib.cpp: In function ‘void Twp::sqgame_register_constants(HSQUIRRELVM)’:
./engines/twp/ids.h:80:23: warning: overflow in conversion from ‘long unsigned int’ to ‘int’ changes value from ‘18446744071562067968’ to ‘-2147483648’ [-Woverflow]
 #define ALIGN_TOP     0xFFFFFFFF80000000
                       ^~~~~~~~~~~~~~~~~~
engines/twp/syslib.cpp:815:34: note: in expansion of macro ‘ALIGN_TOP’
         regConst(v, "ALIGN_TOP", ALIGN_TOP);
                                  ^~~~~~~~~
In file included from engines/twp/objlib.cpp:31:
engines/twp/squirrel/sqvm.h: In copy constructor ‘SQExceptionTrap::SQExceptionTrap(const SQExceptionTrap&)’:
engines/twp/squirrel/sqvm.h:23:60: warning: implicitly-declared ‘SQExceptionTrap& SQExceptionTrap::operator=(const SQExceptionTrap&)’ is deprecated [-Wdeprecated-copy]
     SQExceptionTrap(const SQExceptionTrap &et) { (*this) = et;  }
                                                            ^~
engines/twp/squirrel/sqvm.h:23:5: note: because ‘SQExceptionTrap’ has user-provided ‘SQExceptionTrap::SQExceptionTrap(const SQExceptionTrap&)’
     SQExceptionTrap(const SQExceptionTrap &et) { (*this) = et;  }
     ^~~~~~~~~~~~~~~
In file included from engines/twp/genlib.cpp:29:
./engines/twp/squirrel/sqvm.h: In copy constructor ‘SQExceptionTrap::SQExceptionTrap(const SQExceptionTrap&)’:
./engines/twp/squirrel/sqvm.h:23:60: warning: implicitly-declared ‘SQExceptionTrap& SQExceptionTrap::operator=(const SQExceptionTrap&)’ is deprecated [-Wdeprecated-copy]
     SQExceptionTrap(const SQExceptionTrap &et) { (*this) = et;  }
                                                            ^~
./engines/twp/squirrel/sqvm.h:23:5: note: because ‘SQExceptionTrap’ has user-provided ‘SQExceptionTrap::SQExceptionTrap(const SQExceptionTrap&)’
     SQExceptionTrap(const SQExceptionTrap &et) { (*this) = et;  }
     ^~~~~~~~~~~~~~~
In file included from engines/twp/squtil.cpp:27:
engines/twp/squirrel/sqvm.h: In copy constructor ‘SQExceptionTrap::SQExceptionTrap(const SQExceptionTrap&)’:
engines/twp/squirrel/sqvm.h:23:60: warning: implicitly-declared ‘SQExceptionTrap& SQExceptionTrap::operator=(const SQExceptionTrap&)’ is deprecated [-Wdeprecated-copy]
     SQExceptionTrap(const SQExceptionTrap &et) { (*this) = et;  }
                                                            ^~
engines/twp/squirrel/sqvm.h:23:5: note: because ‘SQExceptionTrap’ has user-provided ‘SQExceptionTrap::SQExceptionTrap(const SQExceptionTrap&)’
     SQExceptionTrap(const SQExceptionTrap &et) { (*this) = et;  }
     ^~~~~~~~~~~~~~~
````